### PR TITLE
fix: add graphql and node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,10 +30,22 @@
       "integrity": "sha512-GpKm6eL8EhNtlDdNDM/r8dAz8kdoYWjU4GFZGc4NARYNJgsoBjaVSo5tDAUebTr/uDioWULKpk44KgmFyFBlPw==",
       "dev": true
     },
+    "@types/graphql": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.13.4.tgz",
+      "integrity": "sha512-B4yel4ro2nTb3v0pYO8vO6SjgvFJSrwUY+IO6TUSLdOSB+gQFslylrhRCHxvXMIhxB71mv5PEE9dAX+24S8sew==",
+      "dev": true
+    },
     "@types/jest": {
       "version": "23.3.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.1.tgz",
       "integrity": "sha512-/UMY+2GkOZ27Vrc51pqC5J8SPd39FKt7kkoGAtWJ8s4msj0b15KehDWIiJpWY3/7tLxBQLLzJhIBhnEsXdzpgw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.7.tgz",
+      "integrity": "sha512-VkKcfuitP+Nc/TaTFH0B8qNmn+6NbI6crLkQonbedViVz7O2w8QV/GERPlkJ4bg42VGHiEWa31CoTOPs1q6z1w==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   },
   "devDependencies": {
     "@types/capitalize": "1.0.1",
+    "@types/graphql": "^0.13.4",
     "@types/jest": "23.3.1",
+    "@types/node": "^10.5.7",
     "@types/prettier": "1.13.2",
     "@types/yargs": "11.1.1",
     "jest": "23.4.2",


### PR DESCRIPTION
fixes errors like `error TS2307: Cannot find module 'os'.` and `TS7016: Could not find a declaration file for module 'graphql'.` as in https://circleci.com/gh/prismagraphql/graphql-resolver-codegen/8.

These errors still remain when running `npm install`:

```sh
src/source-helper.ts:89:9 - error TS2345: Argument of type 'ReadonlyArray<FieldDefinitionNode> | undefined' is not assignable to parameter of type 'ASTNode'.
  Type 'undefined' is not assignable to type 'ASTNode'.

89   visit(node.fields, {
           ~~~~~~~~~~~

src/source-helper.ts:94:13 - error TS2345: Argument of type 'ReadonlyArray<InputValueDefinitionNode> | undefined' is not assignable to parameter of type 'ASTNod
e'.
  Type 'undefined' is not assignable to type 'ASTNode'.

94       visit(fieldNode.arguments, {
               ~~~~~~~~~~~~~~~~~~~

src/source-helper.ts:135:9 - error TS2345: Argument of type 'ReadonlyArray<EnumValueDefinitionNode> | undefined' is not assignable to parameter of type 'ASTNode
'.
  Type 'undefined' is not assignable to type 'ASTNode'.

135   visit(node.values, {
```