### PR TITLE
Fix support for `input` types

### DIFF
--- a/src/generators/ts-generator.ts
+++ b/src/generators/ts-generator.ts
@@ -77,7 +77,7 @@ export function generate(args: GenerateArgs) {
     }, {})
 
   // TODO: Type this
-  const typeToInputTypeAssociation: {[s: string]: any} = args.types
+  const typeToInputTypeAssociation: {[s: string]: string[]} = args.types
     .filter(
       type =>
         type.type.isObject &&
@@ -115,11 +115,13 @@ ${args.types
     .map(
       type => `export namespace ${type.name}Resolvers {
 
-        ${typeToInputTypeAssociation[type.name] ? `export interface ${inputTypesMap[typeToInputTypeAssociation[type.name]].name} {
-          ${inputTypesMap[typeToInputTypeAssociation[type.name]].fields.map(
-            field => `${field.name}: ${getTypeFromGraphQLType(field.type.name)}`
-          )}
-        }` : ``}  
+        ${typeToInputTypeAssociation[type.name] ? typeToInputTypeAssociation[type.name].map(typeAssociation => {
+          return `export interface ${inputTypesMap[typeAssociation].name} {
+            ${inputTypesMap[typeAssociation].fields.map(
+              field => `${field.name}: ${getTypeFromGraphQLType(field.type.name)}`
+            )}
+          }`
+        }).join(os.EOL) : ``}
 
   ${type.fields
     .map(

--- a/src/tests/fixtures/input.graphql
+++ b/src/tests/fixtures/input.graphql
@@ -8,6 +8,16 @@ input AddMemberData {
   projects: [ID!]!
 }
 
+type RemoveMemberPayload {
+  userId: ID!
+}
+
+input RemoveMemberData {
+  email: String!
+  projects: [ID!]!
+}
+
 type Mutation {
   addMember(data: AddMemberData!): AddMemberPayload!
+  removeMember(data: RemoveMemberData!): RemoveMemberPayload!
 }

--- a/src/tests/fixtures/schema.graphql
+++ b/src/tests/fixtures/schema.graphql
@@ -36,6 +36,25 @@ type Mutation {
     checkOut: String!
     numGuests: Int!
   ): MutationResult!
+
+  followUser(input: FollowUserInput!): FollowUserPayload
+  unfollowUser(input: UnfollowUserInput!): UnfollowUserPayload
+}
+
+input FollowUserInput {
+  userId: ID!
+}
+
+type FollowUserPayload {
+  user: User
+}
+
+input UnfollowUserInput {
+  userId: ID!
+}
+
+type UnfollowUserPayload {
+  user: User
 }
 
 type Viewer {

--- a/src/tests/flow/__snapshots__/basic.test.ts.snap
+++ b/src/tests/flow/__snapshots__/basic.test.ts.snap
@@ -97,6 +97,8 @@ export interface ITypeMap {
 
   AddMemberPayloadParent: any;
   AddMemberDataParent: any;
+  RemoveMemberPayloadParent: any;
+  RemoveMemberDataParent: any;
   MutationParent: any;
 }
 
@@ -158,6 +160,51 @@ export type AddMemberData_Type<T> = {
   ) => string[]
 };
 
+export type RemoveMemberPayload_UserId_Resolver<T> = (
+  parent: $PropertyType<T & ITypeMap, \\"RemoveMemberPayloadParent\\">,
+  args: {},
+  ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+  info: GraphQLResolveInfo
+) => string | Promise<string>;
+
+export type RemoveMemberPayload_Type<T> = {
+  userId: (
+    parent: $PropertyType<T & ITypeMap, \\"RemoveMemberPayloadParent\\">,
+    args: {},
+    ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+    info: GraphQLResolveInfo
+  ) => string
+};
+
+export type RemoveMemberData_Email_Resolver<T> = (
+  parent: $PropertyType<T & ITypeMap, \\"RemoveMemberDataParent\\">,
+  args: {},
+  ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+  info: GraphQLResolveInfo
+) => string | Promise<string>;
+
+export type RemoveMemberData_Projects_Resolver<T> = (
+  parent: $PropertyType<T & ITypeMap, \\"RemoveMemberDataParent\\">,
+  args: {},
+  ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+  info: GraphQLResolveInfo
+) => string[] | Promise<string[]>;
+
+export type RemoveMemberData_Type<T> = {
+  email: (
+    parent: $PropertyType<T & ITypeMap, \\"RemoveMemberDataParent\\">,
+    args: {},
+    ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+    info: GraphQLResolveInfo
+  ) => string,
+  projects: (
+    parent: $PropertyType<T & ITypeMap, \\"RemoveMemberDataParent\\">,
+    args: {},
+    ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+    info: GraphQLResolveInfo
+  ) => string[]
+};
+
 // Type for argument
 export type Mutation_AddMember_Args = {
   data: $PropertyType<T & ITypeMap, \\"AddMemberDataParent\\">
@@ -172,18 +219,40 @@ export type Mutation_AddMember_Resolver<T> = (
   | $PropertyType<T & ITypeMap, \\"AddMemberPayloadParent\\">
   | Promise<$PropertyType<T & ITypeMap, \\"AddMemberPayloadParent\\">>;
 
+// Type for argument
+export type Mutation_RemoveMember_Args = {
+  data: $PropertyType<T & ITypeMap, \\"RemoveMemberDataParent\\">
+};
+
+export type Mutation_RemoveMember_Resolver<T> = (
+  parent: $PropertyType<T & ITypeMap, \\"MutationParent\\">,
+  args: Mutation_RemoveMember_Args,
+  ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+  info: GraphQLResolveInfo
+) =>
+  | $PropertyType<T & ITypeMap, \\"RemoveMemberPayloadParent\\">
+  | Promise<$PropertyType<T & ITypeMap, \\"RemoveMemberPayloadParent\\">>;
+
 export type Mutation_Type<T> = {
   addMember: (
     parent: $PropertyType<T & ITypeMap, \\"MutationParent\\">,
     args: Mutation_AddMember_Args,
     ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
     info: GraphQLResolveInfo
-  ) => $PropertyType<T & ITypeMap, \\"AddMemberPayloadParent\\">
+  ) => $PropertyType<T & ITypeMap, \\"AddMemberPayloadParent\\">,
+  removeMember: (
+    parent: $PropertyType<T & ITypeMap, \\"MutationParent\\">,
+    args: Mutation_RemoveMember_Args,
+    ctx: $PropertyType<T & ITypeMap, \\"Context\\">,
+    info: GraphQLResolveInfo
+  ) => $PropertyType<T & ITypeMap, \\"RemoveMemberPayloadParent\\">
 };
 
 export type IResolvers<T> = {
   AddMemberPayload: AddMemberPayload_Type<T>,
   AddMemberData: AddMemberData_Type<T>,
+  RemoveMemberPayload: RemoveMemberPayload_Type<T>,
+  RemoveMemberData: RemoveMemberData_Type<T>,
   Mutation: Mutation_Type<T>
 };
 "

--- a/src/tests/flow/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/flow/__snapshots__/large-schema.test.ts.snap
@@ -9,6 +9,8 @@ export interface ITypeMap {
 
   QueryParent: any;
   MutationParent: any;
+  FollowUserPayloadParent: any;
+  UnfollowUserPayloadParent: any;
   ViewerParent: any;
   AuthPayloadParent: any;
   MutationResultParent: any;
@@ -160,6 +162,13 @@ export namespace QueryResolvers {
 }
 
 export namespace MutationResolvers {
+  export interface FollowUserInput {
+    userId: string;
+  }
+  export interface UnfollowUserInput {
+    userId: string;
+  }
+
   export interface ArgsSignup<T extends ITypeMap> {
     email: string;
     password: string;
@@ -219,6 +228,34 @@ export namespace MutationResolvers {
     info: GraphQLResolveInfo
   ) => T[\\"MutationResultParent\\"] | Promise<T[\\"MutationResultParent\\"]>;
 
+  export interface ArgsFollowUser<T extends ITypeMap> {
+    input: FollowUserInput;
+  }
+
+  export type FollowUserResolver<T extends ITypeMap> = (
+    parent: T[\\"MutationParent\\"],
+    args: ArgsFollowUser<T>,
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) =>
+    | T[\\"FollowUserPayloadParent\\"]
+    | null
+    | Promise<T[\\"FollowUserPayloadParent\\"] | null>;
+
+  export interface ArgsUnfollowUser<T extends ITypeMap> {
+    input: UnfollowUserInput;
+  }
+
+  export type UnfollowUserResolver<T extends ITypeMap> = (
+    parent: T[\\"MutationParent\\"],
+    args: ArgsUnfollowUser<T>,
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) =>
+    | T[\\"UnfollowUserPayloadParent\\"]
+    | null
+    | Promise<T[\\"UnfollowUserPayloadParent\\"] | null>;
+
   export interface Type<T extends ITypeMap> {
     signup: (
       parent: T[\\"MutationParent\\"],
@@ -244,6 +281,60 @@ export namespace MutationResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => T[\\"MutationResultParent\\"] | Promise<T[\\"MutationResultParent\\"]>;
+    followUser: (
+      parent: T[\\"MutationParent\\"],
+      args: ArgsFollowUser<T>,
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) =>
+      | T[\\"FollowUserPayloadParent\\"]
+      | null
+      | Promise<T[\\"FollowUserPayloadParent\\"] | null>;
+    unfollowUser: (
+      parent: T[\\"MutationParent\\"],
+      args: ArgsUnfollowUser<T>,
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) =>
+      | T[\\"UnfollowUserPayloadParent\\"]
+      | null
+      | Promise<T[\\"UnfollowUserPayloadParent\\"] | null>;
+  }
+}
+
+export namespace FollowUserPayloadResolvers {
+  export type UserResolver<T extends ITypeMap> = (
+    parent: T[\\"FollowUserPayloadParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
+
+  export interface Type<T extends ITypeMap> {
+    user: (
+      parent: T[\\"FollowUserPayloadParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
+  }
+}
+
+export namespace UnfollowUserPayloadResolvers {
+  export type UserResolver<T extends ITypeMap> = (
+    parent: T[\\"UnfollowUserPayloadParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
+
+  export interface Type<T extends ITypeMap> {
+    user: (
+      parent: T[\\"UnfollowUserPayloadParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
   }
 }
 
@@ -3309,6 +3400,8 @@ export namespace AmenitiesResolvers {
 export interface IResolvers<T extends ITypeMap> {
   Query: QueryResolvers.Type<T>;
   Mutation: MutationResolvers.Type<T>;
+  FollowUserPayload: FollowUserPayloadResolvers.Type<T>;
+  UnfollowUserPayload: UnfollowUserPayloadResolvers.Type<T>;
   Viewer: ViewerResolvers.Type<T>;
   AuthPayload: AuthPayloadResolvers.Type<T>;
   MutationResult: MutationResultResolvers.Type<T>;

--- a/src/tests/reason/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/reason/__snapshots__/large-schema.test.ts.snap
@@ -6,6 +6,14 @@ exports[`large schema 1`] = `
 
   type mutation = {.};
 
+  type followUserInput = {. \\"userId\\": string};
+
+  type followUserPayload = {.};
+
+  type unfollowUserInput = {. \\"userId\\": string};
+
+  type unfollowUserPayload = {.};
+
   type viewer = {.};
 
   type authPayload = {. \\"token\\": string};
@@ -352,6 +360,10 @@ module Mutation = {
     \\"numGuests\\": Data.mutationResult,
   };
 
+  type followUserArgument = {. \\"input\\": Data.followUserPayload};
+
+  type unfollowUserArgument = {. \\"input\\": Data.unfollowUserPayload};
+
   type parent;
   type args;
   type context;
@@ -364,7 +376,47 @@ module Mutation = {
     \\"addPaymentMethod\\":
       (parent, addPaymentMethodArgument, context, info) => Data.mutationResult,
     \\"book\\": (parent, bookArgument, context, info) => Data.mutationResult,
+    \\"followUser\\":
+      (parent, followUserArgument, context, info) => Data.followUserPayload,
+    \\"unfollowUser\\":
+      (parent, unfollowUserArgument, context, info) => Data.unfollowUserPayload,
   };
+};
+
+module FollowUserInput = {
+  type parent;
+  type args;
+  type context;
+  type info;
+
+  type resolvers = {.};
+};
+
+module FollowUserPayload = {
+  type parent;
+  type args;
+  type context;
+  type info;
+
+  type resolvers = {. \\"user\\": (parent, args, context, info) => Data.user};
+};
+
+module UnfollowUserInput = {
+  type parent;
+  type args;
+  type context;
+  type info;
+
+  type resolvers = {.};
+};
+
+module UnfollowUserPayload = {
+  type parent;
+  type args;
+  type context;
+  type info;
+
+  type resolvers = {. \\"user\\": (parent, args, context, info) => Data.user};
 };
 
 module Viewer = {

--- a/src/tests/scaffold-flow/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/scaffold-flow/__snapshots__/large-schema.test.ts.snap
@@ -3,6 +3,38 @@
 exports[`large schema 1`] = `
 Array [
   Object {
+    "code": "import { FollowUserPayloadResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { TypeMap } from \\"./types/TypeMap\\";
+import { UserParent } from \\"./User\\";
+
+export interface FollowUserPayloadParent {
+  user?: UserParent;
+}
+
+export const FollowUserPayload: FollowUserPayloadResolvers.Type<TypeMap> = {
+  user: parent => parent.user
+};
+",
+    "force": false,
+    "path": "FollowUserPayload.ts",
+  },
+  Object {
+    "code": "import { UnfollowUserPayloadResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { TypeMap } from \\"./types/TypeMap\\";
+import { UserParent } from \\"./User\\";
+
+export interface UnfollowUserPayloadParent {
+  user?: UserParent;
+}
+
+export const UnfollowUserPayload: UnfollowUserPayloadResolvers.Type<TypeMap> = {
+  user: parent => parent.user
+};
+",
+    "force": false,
+    "path": "UnfollowUserPayload.ts",
+  },
+  Object {
     "code": "import { ViewerResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
 import { TypeMap } from \\"./types/TypeMap\\";
 import { UserParent } from \\"./User\\";
@@ -921,7 +953,9 @@ export const Mutation: MutationResolvers.Type<TypeMap> = {
   },
   book: (parent, args) => {
     throw new Error(\\"Resolver not implemented\\");
-  }
+  },
+  followUser: (parent, args) => null,
+  unfollowUser: (parent, args) => null
 };
 ",
     "force": false,
@@ -938,6 +972,8 @@ export const Mutation: MutationResolvers.Type<TypeMap> = {
 
 import { QueryParent } from \\"../Query\\";
 import { MutationParent } from \\"../Mutation\\";
+import { FollowUserPayloadParent } from \\"../FollowUserPayload\\";
+import { UnfollowUserPayloadParent } from \\"../UnfollowUserPayload\\";
 import { ViewerParent } from \\"../Viewer\\";
 import { AuthPayloadParent } from \\"../AuthPayload\\";
 import { MutationResultParent } from \\"../MutationResult\\";
@@ -973,6 +1009,8 @@ export interface TypeMap extends ITypeMap {
   Context: Context;
   QueryParent: QueryParent;
   MutationParent: MutationParent;
+  FollowUserPayloadParent: FollowUserPayloadParent;
+  UnfollowUserPayloadParent: UnfollowUserPayloadParent;
   ViewerParent: ViewerParent;
   AuthPayloadParent: AuthPayloadParent;
   MutationResultParent: MutationResultParent;
@@ -1012,6 +1050,8 @@ import { TypeMap } from \\"./types/TypeMap\\";
 
 import { Query } from \\"./Query\\";
 import { Mutation } from \\"./Mutation\\";
+import { FollowUserPayload } from \\"./FollowUserPayload\\";
+import { UnfollowUserPayload } from \\"./UnfollowUserPayload\\";
 import { Viewer } from \\"./Viewer\\";
 import { AuthPayload } from \\"./AuthPayload\\";
 import { MutationResult } from \\"./MutationResult\\";
@@ -1044,6 +1084,8 @@ import { Amenities } from \\"./Amenities\\";
 export const resolvers: IResolvers<TypeMap> = {
   Query,
   Mutation,
+  FollowUserPayload,
+  UnfollowUserPayload,
   Viewer,
   AuthPayload,
   MutationResult,

--- a/src/tests/scaffold-flow/large-schema.test.ts
+++ b/src/tests/scaffold-flow/large-schema.test.ts
@@ -14,5 +14,5 @@ test("large schema", async () => {
     generator: "scaffold-typescript"
   });
   expect(code).toMatchSnapshot();
-  expect(code.length).toBe(33);
+  expect(code.length).toBe(35);
 });

--- a/src/tests/scaffold-typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/scaffold-typescript/__snapshots__/large-schema.test.ts.snap
@@ -3,6 +3,38 @@
 exports[`large schema 1`] = `
 Array [
   Object {
+    "code": "import { FollowUserPayloadResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { TypeMap } from \\"./types/TypeMap\\";
+import { UserParent } from \\"./User\\";
+
+export interface FollowUserPayloadParent {
+  user?: UserParent;
+}
+
+export const FollowUserPayload: FollowUserPayloadResolvers.Type<TypeMap> = {
+  user: parent => parent.user
+};
+",
+    "force": false,
+    "path": "FollowUserPayload.ts",
+  },
+  Object {
+    "code": "import { UnfollowUserPayloadResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { TypeMap } from \\"./types/TypeMap\\";
+import { UserParent } from \\"./User\\";
+
+export interface UnfollowUserPayloadParent {
+  user?: UserParent;
+}
+
+export const UnfollowUserPayload: UnfollowUserPayloadResolvers.Type<TypeMap> = {
+  user: parent => parent.user
+};
+",
+    "force": false,
+    "path": "UnfollowUserPayload.ts",
+  },
+  Object {
     "code": "import { ViewerResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
 import { TypeMap } from \\"./types/TypeMap\\";
 import { UserParent } from \\"./User\\";
@@ -921,7 +953,9 @@ export const Mutation: MutationResolvers.Type<TypeMap> = {
   },
   book: (parent, args) => {
     throw new Error(\\"Resolver not implemented\\");
-  }
+  },
+  followUser: (parent, args) => null,
+  unfollowUser: (parent, args) => null
 };
 ",
     "force": false,
@@ -938,6 +972,8 @@ export const Mutation: MutationResolvers.Type<TypeMap> = {
 
 import { QueryParent } from \\"../Query\\";
 import { MutationParent } from \\"../Mutation\\";
+import { FollowUserPayloadParent } from \\"../FollowUserPayload\\";
+import { UnfollowUserPayloadParent } from \\"../UnfollowUserPayload\\";
 import { ViewerParent } from \\"../Viewer\\";
 import { AuthPayloadParent } from \\"../AuthPayload\\";
 import { MutationResultParent } from \\"../MutationResult\\";
@@ -973,6 +1009,8 @@ export interface TypeMap extends ITypeMap {
   Context: Context;
   QueryParent: QueryParent;
   MutationParent: MutationParent;
+  FollowUserPayloadParent: FollowUserPayloadParent;
+  UnfollowUserPayloadParent: UnfollowUserPayloadParent;
   ViewerParent: ViewerParent;
   AuthPayloadParent: AuthPayloadParent;
   MutationResultParent: MutationResultParent;
@@ -1012,6 +1050,8 @@ import { TypeMap } from \\"./types/TypeMap\\";
 
 import { Query } from \\"./Query\\";
 import { Mutation } from \\"./Mutation\\";
+import { FollowUserPayload } from \\"./FollowUserPayload\\";
+import { UnfollowUserPayload } from \\"./UnfollowUserPayload\\";
 import { Viewer } from \\"./Viewer\\";
 import { AuthPayload } from \\"./AuthPayload\\";
 import { MutationResult } from \\"./MutationResult\\";
@@ -1044,6 +1084,8 @@ import { Amenities } from \\"./Amenities\\";
 export const resolvers: IResolvers<TypeMap> = {
   Query,
   Mutation,
+  FollowUserPayload,
+  UnfollowUserPayload,
   Viewer,
   AuthPayload,
   MutationResult,

--- a/src/tests/scaffold-typescript/large-schema.test.ts
+++ b/src/tests/scaffold-typescript/large-schema.test.ts
@@ -14,5 +14,5 @@ test("large schema", async () => {
     generator: "scaffold-typescript"
   });
   expect(code).toMatchSnapshot();
-  expect(code.length).toBe(33);
+  expect(code.length).toBe(35);
 });

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -94,6 +94,7 @@ export interface ITypeMap {
   Context: any;
 
   AddMemberPayloadParent: any;
+  RemoveMemberPayloadParent: any;
   MutationParent: any;
 }
 
@@ -128,8 +129,30 @@ export namespace AddMemberPayloadResolvers {
   }
 }
 
+export namespace RemoveMemberPayloadResolvers {
+  export type UserIdResolver<T extends ITypeMap> = (
+    parent: T[\\"RemoveMemberPayloadParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export interface Type<T extends ITypeMap> {
+    userId: (
+      parent: T[\\"RemoveMemberPayloadParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+  }
+}
+
 export namespace MutationResolvers {
   export interface AddMemberData {
+    email: string;
+    projects: string;
+  }
+  export interface RemoveMemberData {
     email: string;
     projects: string;
   }
@@ -145,6 +168,17 @@ export namespace MutationResolvers {
     info: GraphQLResolveInfo
   ) => T[\\"AddMemberPayloadParent\\"] | Promise<T[\\"AddMemberPayloadParent\\"]>;
 
+  export interface ArgsRemoveMember<T extends ITypeMap> {
+    data: RemoveMemberData;
+  }
+
+  export type RemoveMemberResolver<T extends ITypeMap> = (
+    parent: T[\\"MutationParent\\"],
+    args: ArgsRemoveMember<T>,
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => T[\\"RemoveMemberPayloadParent\\"] | Promise<T[\\"RemoveMemberPayloadParent\\"]>;
+
   export interface Type<T extends ITypeMap> {
     addMember: (
       parent: T[\\"MutationParent\\"],
@@ -152,11 +186,20 @@ export namespace MutationResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => T[\\"AddMemberPayloadParent\\"] | Promise<T[\\"AddMemberPayloadParent\\"]>;
+    removeMember: (
+      parent: T[\\"MutationParent\\"],
+      args: ArgsRemoveMember<T>,
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) =>
+      | T[\\"RemoveMemberPayloadParent\\"]
+      | Promise<T[\\"RemoveMemberPayloadParent\\"]>;
   }
 }
 
 export interface IResolvers<T extends ITypeMap> {
   AddMemberPayload: AddMemberPayloadResolvers.Type<T>;
+  RemoveMemberPayload: RemoveMemberPayloadResolvers.Type<T>;
   Mutation: MutationResolvers.Type<T>;
 }
 "

--- a/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -9,6 +9,8 @@ export interface ITypeMap {
 
   QueryParent: any;
   MutationParent: any;
+  FollowUserPayloadParent: any;
+  UnfollowUserPayloadParent: any;
   ViewerParent: any;
   AuthPayloadParent: any;
   MutationResultParent: any;
@@ -160,6 +162,13 @@ export namespace QueryResolvers {
 }
 
 export namespace MutationResolvers {
+  export interface FollowUserInput {
+    userId: string;
+  }
+  export interface UnfollowUserInput {
+    userId: string;
+  }
+
   export interface ArgsSignup<T extends ITypeMap> {
     email: string;
     password: string;
@@ -219,6 +228,34 @@ export namespace MutationResolvers {
     info: GraphQLResolveInfo
   ) => T[\\"MutationResultParent\\"] | Promise<T[\\"MutationResultParent\\"]>;
 
+  export interface ArgsFollowUser<T extends ITypeMap> {
+    input: FollowUserInput;
+  }
+
+  export type FollowUserResolver<T extends ITypeMap> = (
+    parent: T[\\"MutationParent\\"],
+    args: ArgsFollowUser<T>,
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) =>
+    | T[\\"FollowUserPayloadParent\\"]
+    | null
+    | Promise<T[\\"FollowUserPayloadParent\\"] | null>;
+
+  export interface ArgsUnfollowUser<T extends ITypeMap> {
+    input: UnfollowUserInput;
+  }
+
+  export type UnfollowUserResolver<T extends ITypeMap> = (
+    parent: T[\\"MutationParent\\"],
+    args: ArgsUnfollowUser<T>,
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) =>
+    | T[\\"UnfollowUserPayloadParent\\"]
+    | null
+    | Promise<T[\\"UnfollowUserPayloadParent\\"] | null>;
+
   export interface Type<T extends ITypeMap> {
     signup: (
       parent: T[\\"MutationParent\\"],
@@ -244,6 +281,60 @@ export namespace MutationResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => T[\\"MutationResultParent\\"] | Promise<T[\\"MutationResultParent\\"]>;
+    followUser: (
+      parent: T[\\"MutationParent\\"],
+      args: ArgsFollowUser<T>,
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) =>
+      | T[\\"FollowUserPayloadParent\\"]
+      | null
+      | Promise<T[\\"FollowUserPayloadParent\\"] | null>;
+    unfollowUser: (
+      parent: T[\\"MutationParent\\"],
+      args: ArgsUnfollowUser<T>,
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) =>
+      | T[\\"UnfollowUserPayloadParent\\"]
+      | null
+      | Promise<T[\\"UnfollowUserPayloadParent\\"] | null>;
+  }
+}
+
+export namespace FollowUserPayloadResolvers {
+  export type UserResolver<T extends ITypeMap> = (
+    parent: T[\\"FollowUserPayloadParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
+
+  export interface Type<T extends ITypeMap> {
+    user: (
+      parent: T[\\"FollowUserPayloadParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
+  }
+}
+
+export namespace UnfollowUserPayloadResolvers {
+  export type UserResolver<T extends ITypeMap> = (
+    parent: T[\\"UnfollowUserPayloadParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
+
+  export interface Type<T extends ITypeMap> {
+    user: (
+      parent: T[\\"UnfollowUserPayloadParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => T[\\"UserParent\\"] | null | Promise<T[\\"UserParent\\"] | null>;
   }
 }
 
@@ -3309,6 +3400,8 @@ export namespace AmenitiesResolvers {
 export interface IResolvers<T extends ITypeMap> {
   Query: QueryResolvers.Type<T>;
   Mutation: MutationResolvers.Type<T>;
+  FollowUserPayload: FollowUserPayloadResolvers.Type<T>;
+  UnfollowUserPayload: UnfollowUserPayloadResolvers.Type<T>;
   Viewer: ViewerResolvers.Type<T>;
   AuthPayload: AuthPayloadResolvers.Type<T>;
   MutationResult: MutationResultResolvers.Type<T>;


### PR DESCRIPTION
~This PR is to demonstrate a failing use case.~

~It's not clear to me why these particular mutations cause errors.~

~when I leave one of the two out, it works just fine.~

After digging a bit deeper, it turned out that `input` types were not working in general, but I managed to get them working.

fixes: #64