### PR TITLE
Generate resolvers for interfaces and union types

### DIFF
--- a/src/generators/generator-interface.ts
+++ b/src/generators/generator-interface.ts
@@ -2,13 +2,15 @@ import * as prettier from "prettier";
 import {
   GraphQLTypeObject,
   GraphQLEnumObject,
-  GraphQLUnionObject
+  GraphQLUnionObject,
+  GraphQLInterfaceObject
 } from "../source-helper";
 
 export type GenerateArgs = {
   types: GraphQLTypeObject[];
   enums: GraphQLEnumObject[];
   unions: GraphQLUnionObject[];
+  interfaces: GraphQLInterfaceObject[];
 };
 
 export interface CodeFileLike {

--- a/src/generators/ts-generator.ts
+++ b/src/generators/ts-generator.ts
@@ -58,7 +58,7 @@ export function printFieldLikeType(
       type => lookupType ? `T['${type}Parent']` : `${type}Parent`
     ).join(' | ');
     if (field.type.isArray) {
-      types = `Array<${types}>`;
+      types = `Array<${types}>`
     }
 
     return `${types}${
@@ -80,7 +80,11 @@ export function printFieldLikeType(
 }
 
 function isInterfaceObject(obj: GraphQLInterfaceObject | GraphQLTypeObject): obj is GraphQLInterfaceObject {
-  return obj.type.isInterface;
+  return obj.type.isInterface
+}
+
+function isTypeObject(obj: GraphQLInterfaceObject | GraphQLTypeObject): obj is GraphQLTypeObject {
+  return obj.type.isObject
 }
 
 export function generate(args: GenerateArgs) {
@@ -138,7 +142,7 @@ Context: any
 ${args.enums.map(e => `${e.name}: any`).join(os.EOL)}
 ${args.unions.map(union => `${union.name}: any`).join(os.EOL)}
 ${args.types
-    .filter(type => type.type.isObject)
+    .filter(isTypeObject)
     .map(type => `${type.name}Parent: any`)
     .join(os.EOL)}
 }
@@ -187,7 +191,11 @@ ${args.types
     )
     .join(os.EOL)}
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap> ${
+    isTypeObject(type) && type.interfaces && type.interfaces.length
+     ? `extends ${type.interfaces.map(typeInterface => `${typeInterface}Resolvers.Type<T>`).join(', ')}`
+     : ''
+    } {
   ${type.fields
     .map(
       field => `${field.name}: (

--- a/src/generators/ts-scaffolder.ts
+++ b/src/generators/ts-scaffolder.ts
@@ -44,6 +44,14 @@ function isParentType(name: string) {
 }
 
 export function generate(args: GenerateArgs): CodeFileLike[] {
+  const interfacesMap: { [s: string]: string[] } = args.interfaces
+    .reduce((interfaces, int) => {
+      return {
+        ...interfaces,
+        [int.name]: int.types.map(type => type.name)
+      }
+    }, {});
+
   let files: CodeFileLike[] = args.types
     .filter(type => type.type.isObject)
     .filter(type => !isParentType(type.name))
@@ -93,6 +101,7 @@ export function generate(args: GenerateArgs): CodeFileLike[] {
           field => `
       ${field.name}${!field.type.isRequired ? "?" : ""}: ${printFieldLikeType(
             field,
+            interfacesMap,
             false
           ).replace("| null", "")}
       `

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import * as os from "os";
 import {
   extractGraphQLTypes,
   extractGraphQLEnums,
-  extractGraphQLUnions
+  extractGraphQLUnions,
+  extractGraphQLInterfaces
 } from "./source-helper";
 import {
   IGenerator,
@@ -106,7 +107,8 @@ export function generateCode({
   const generateArgs: GenerateArgs = {
     types: extractGraphQLTypes(schema!),
     enums: extractGraphQLEnums(schema!),
-    unions: extractGraphQLUnions(schema!)
+    unions: extractGraphQLUnions(schema!),
+    interfaces: extractGraphQLInterfaces(schema!)
   };
   const generatorFn: IGenerator = getGenerator(generator);
   const code = generatorFn.generate(generateArgs);

--- a/src/tests/fixtures/interface.graphql
+++ b/src/tests/fixtures/interface.graphql
@@ -1,0 +1,27 @@
+interface Media {
+  id: ID!
+  url: String!
+}
+
+type Video implements Media {
+  id: ID!
+  name: String!
+  duration: Int!
+}
+
+type Picture implements Media {
+  id: ID!
+  url: String!
+  width: Int!
+  height: Int!
+}
+
+type Home {
+  id: ID!
+  name: String
+  description: String!
+  numRatings: Int!
+  avgRating: Float
+  media(first: Int): [Media!]!
+  perNight: Int!
+}

--- a/src/tests/fixtures/schema.graphql
+++ b/src/tests/fixtures/schema.graphql
@@ -63,7 +63,7 @@ type Home {
   description: String!
   numRatings: Int!
   avgRating: Float
-  pictures(first: Int): [Picture!]!
+  media(first: Int): [Media!]!
   perNight: Int!
 }
 
@@ -120,9 +120,22 @@ type Location {
   directions: String
 }
 
-type Picture {
+interface Media {
   id: ID!
   url: String!
+}
+
+type Video implements Media {
+  id: ID!
+  name: String!
+  duration: Int!
+}
+
+type Picture implements Media {
+  id: ID!
+  url: String!
+  width: Int!
+  height: Int!
 }
 
 type City {

--- a/src/tests/flow/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/flow/__snapshots__/large-schema.test.ts.snap
@@ -2,7 +2,11 @@
 
 exports[`large schema 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -38,6 +42,48 @@ export interface ITypeMap {
   PoliciesParent: any;
   HouseRulesParent: any;
   AmenitiesParent: any;
+}
+
+export namespace MediaResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type UrlResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export interface Interface<T extends ITypeMap> {
+    id: (
+      parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    url: (
+      parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+  }
+
+  export interface Type<T extends ITypeMap> {
+    __resolveType?: GraphQLTypeResolver<
+      T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      T[\\"Context\\"]
+    >;
+    __isTypeOf?: GraphQLIsTypeOfFn<
+      T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      T[\\"Context\\"]
+    >;
+  }
 }
 
 export namespace QueryResolvers {
@@ -1010,7 +1056,8 @@ export namespace VideoResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap>
+    extends MediaResolvers.Interface<T> {
     id: (
       parent: T[\\"VideoParent\\"],
       args: {},
@@ -1061,7 +1108,8 @@ export namespace PictureResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap>
+    extends MediaResolvers.Interface<T> {
     id: (
       parent: T[\\"PictureParent\\"],
       args: {},
@@ -3413,6 +3461,7 @@ export interface IResolvers<T extends ITypeMap> {
   Policies: PoliciesResolvers.Type<T>;
   HouseRules: HouseRulesResolvers.Type<T>;
   Amenities: AmenitiesResolvers.Type<T>;
+  Media?: MediaResolvers.Type<T>;
 }
 "
 `;

--- a/src/tests/flow/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/flow/__snapshots__/large-schema.test.ts.snap
@@ -19,6 +19,7 @@ export interface ITypeMap {
   ReviewParent: any;
   NeighbourhoodParent: any;
   LocationParent: any;
+  VideoParent: any;
   PictureParent: any;
   CityParent: any;
   ExperienceCategoryParent: any;
@@ -394,16 +395,18 @@ export namespace HomeResolvers {
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export interface ArgsPictures<T extends ITypeMap> {
+  export interface ArgsMedia<T extends ITypeMap> {
     first: number | null;
   }
 
-  export type PicturesResolver<T extends ITypeMap> = (
+  export type MediaResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
-    args: ArgsPictures<T>,
+    args: ArgsMedia<T>,
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
-  ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
+  ) =>
+    | Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>
+    | Promise<Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>>;
 
   export type PerNightResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
@@ -443,12 +446,14 @@ export namespace HomeResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
-    pictures: (
+    media: (
       parent: T[\\"HomeParent\\"],
-      args: ArgsPictures<T>,
+      args: ArgsMedia<T>,
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
-    ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
+    ) =>
+      | Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>
+      | Promise<Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>>;
     perNight: (
       parent: T[\\"HomeParent\\"],
       args: {},
@@ -983,6 +988,50 @@ export namespace LocationResolvers {
   }
 }
 
+export namespace VideoResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type NameResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type DurationResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export interface Type<T extends ITypeMap> {
+    id: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    name: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    duration: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+  }
+}
+
 export namespace PictureResolvers {
   export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PictureParent\\"],
@@ -998,6 +1047,20 @@ export namespace PictureResolvers {
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
+  export type WidthResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export type HeightResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
   export interface Type<T extends ITypeMap> {
     id: (
       parent: T[\\"PictureParent\\"],
@@ -1011,6 +1074,18 @@ export namespace PictureResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
+    width: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+    height: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
   }
 }
 
@@ -3319,6 +3394,7 @@ export interface IResolvers<T extends ITypeMap> {
   Review: ReviewResolvers.Type<T>;
   Neighbourhood: NeighbourhoodResolvers.Type<T>;
   Location: LocationResolvers.Type<T>;
+  Video: VideoResolvers.Type<T>;
   Picture: PictureResolvers.Type<T>;
   City: CityResolvers.Type<T>;
   ExperienceCategory: ExperienceCategoryResolvers.Type<T>;

--- a/src/tests/reason/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/reason/__snapshots__/large-schema.test.ts.snap
@@ -74,10 +74,19 @@ exports[`large schema 1`] = `
     \\"directions\\": string,
   };
 
+  type video = {
+    .
+    \\"id\\": string,
+    \\"name\\": string,
+    \\"duration\\": int,
+  };
+
   type picture = {
     .
     \\"id\\": string,
     \\"url\\": string,
+    \\"width\\": int,
+    \\"height\\": int,
   };
 
   type city = {
@@ -413,7 +422,7 @@ module ExperiencesByCity = {
 };
 
 module Home = {
-  type picturesArgument = {. \\"first\\": Js.Array.t(Data.picture)};
+  type mediaArgument = {. \\"first\\": Js.Array.t(Data.media)};
 
   type parent;
   type args;
@@ -422,8 +431,7 @@ module Home = {
 
   type resolvers = {
     .
-    \\"pictures\\":
-      (parent, picturesArgument, context, info) => Js.Array.t(Data.picture),
+    \\"media\\": (parent, mediaArgument, context, info) => Js.Array.t(Data.media),
   };
 };
 
@@ -478,6 +486,15 @@ module Neighbourhood = {
 };
 
 module Location = {
+  type parent;
+  type args;
+  type context;
+  type info;
+
+  type resolvers = {.};
+};
+
+module Video = {
   type parent;
   type args;
   type context;

--- a/src/tests/scaffold-flow/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/scaffold-flow/__snapshots__/large-schema.test.ts.snap
@@ -76,7 +76,7 @@ export const ExperiencesByCity: ExperiencesByCityResolvers.Type<TypeMap> = {
   Object {
     "code": "import { HomeResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
 import { TypeMap } from \\"./types/TypeMap\\";
-import { PictureParent } from \\"./Picture\\";
+import { MediaParent } from \\"./Media\\";
 
 export interface HomeParent {
   id: string;
@@ -84,7 +84,7 @@ export interface HomeParent {
   description: string;
   numRatings: number;
   avgRating?: number;
-  pictures: PictureParent[];
+  media: Array<VideoParent | PictureParent>;
   perNight: number;
 }
 
@@ -94,7 +94,7 @@ export const Home: HomeResolvers.Type<TypeMap> = {
   description: parent => parent.description,
   numRatings: parent => parent.numRatings,
   avgRating: parent => parent.avgRating,
-  pictures: (parent, args) => parent.pictures,
+  media: (parent, args) => parent.media,
   perNight: parent => parent.perNight
 };
 ",
@@ -252,17 +252,40 @@ export const Location: LocationResolvers.Type<TypeMap> = {
     "path": "Location.ts",
   },
   Object {
+    "code": "import { VideoResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { TypeMap } from \\"./types/TypeMap\\";
+
+export interface VideoParent {
+  id: string;
+  name: string;
+  duration: number;
+}
+
+export const Video: VideoResolvers.Type<TypeMap> = {
+  id: parent => parent.id,
+  name: parent => parent.name,
+  duration: parent => parent.duration
+};
+",
+    "force": false,
+    "path": "Video.ts",
+  },
+  Object {
     "code": "import { PictureResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
 import { TypeMap } from \\"./types/TypeMap\\";
 
 export interface PictureParent {
   id: string;
   url: string;
+  width: number;
+  height: number;
 }
 
 export const Picture: PictureResolvers.Type<TypeMap> = {
   id: parent => parent.id,
-  url: parent => parent.url
+  url: parent => parent.url,
+  width: parent => parent.width,
+  height: parent => parent.height
 };
 ",
     "force": false,
@@ -948,6 +971,7 @@ import { ExperienceParent } from \\"../Experience\\";
 import { ReviewParent } from \\"../Review\\";
 import { NeighbourhoodParent } from \\"../Neighbourhood\\";
 import { LocationParent } from \\"../Location\\";
+import { VideoParent } from \\"../Video\\";
 import { PictureParent } from \\"../Picture\\";
 import { CityParent } from \\"../City\\";
 import { ExperienceCategoryParent } from \\"../ExperienceCategory\\";
@@ -983,6 +1007,7 @@ export interface TypeMap extends ITypeMap {
   ReviewParent: ReviewParent;
   NeighbourhoodParent: NeighbourhoodParent;
   LocationParent: LocationParent;
+  VideoParent: VideoParent;
   PictureParent: PictureParent;
   CityParent: CityParent;
   ExperienceCategoryParent: ExperienceCategoryParent;
@@ -1022,6 +1047,7 @@ import { Experience } from \\"./Experience\\";
 import { Review } from \\"./Review\\";
 import { Neighbourhood } from \\"./Neighbourhood\\";
 import { Location } from \\"./Location\\";
+import { Video } from \\"./Video\\";
 import { Picture } from \\"./Picture\\";
 import { City } from \\"./City\\";
 import { ExperienceCategory } from \\"./ExperienceCategory\\";
@@ -1054,6 +1080,7 @@ export const resolvers: IResolvers<TypeMap> = {
   Review,
   Neighbourhood,
   Location,
+  Video,
   Picture,
   City,
   ExperienceCategory,

--- a/src/tests/scaffold-flow/large-schema.test.ts
+++ b/src/tests/scaffold-flow/large-schema.test.ts
@@ -14,5 +14,5 @@ test("large schema", async () => {
     generator: "scaffold-typescript"
   });
   expect(code).toMatchSnapshot();
-  expect(code.length).toBe(33);
+  expect(code.length).toBe(34);
 });

--- a/src/tests/scaffold-typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/scaffold-typescript/__snapshots__/large-schema.test.ts.snap
@@ -76,7 +76,7 @@ export const ExperiencesByCity: ExperiencesByCityResolvers.Type<TypeMap> = {
   Object {
     "code": "import { HomeResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
 import { TypeMap } from \\"./types/TypeMap\\";
-import { PictureParent } from \\"./Picture\\";
+import { MediaParent } from \\"./Media\\";
 
 export interface HomeParent {
   id: string;
@@ -84,7 +84,7 @@ export interface HomeParent {
   description: string;
   numRatings: number;
   avgRating?: number;
-  pictures: PictureParent[];
+  media: Array<VideoParent | PictureParent>;
   perNight: number;
 }
 
@@ -94,7 +94,7 @@ export const Home: HomeResolvers.Type<TypeMap> = {
   description: parent => parent.description,
   numRatings: parent => parent.numRatings,
   avgRating: parent => parent.avgRating,
-  pictures: (parent, args) => parent.pictures,
+  media: (parent, args) => parent.media,
   perNight: parent => parent.perNight
 };
 ",
@@ -252,17 +252,40 @@ export const Location: LocationResolvers.Type<TypeMap> = {
     "path": "Location.ts",
   },
   Object {
+    "code": "import { VideoResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { TypeMap } from \\"./types/TypeMap\\";
+
+export interface VideoParent {
+  id: string;
+  name: string;
+  duration: number;
+}
+
+export const Video: VideoResolvers.Type<TypeMap> = {
+  id: parent => parent.id,
+  name: parent => parent.name,
+  duration: parent => parent.duration
+};
+",
+    "force": false,
+    "path": "Video.ts",
+  },
+  Object {
     "code": "import { PictureResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
 import { TypeMap } from \\"./types/TypeMap\\";
 
 export interface PictureParent {
   id: string;
   url: string;
+  width: number;
+  height: number;
 }
 
 export const Picture: PictureResolvers.Type<TypeMap> = {
   id: parent => parent.id,
-  url: parent => parent.url
+  url: parent => parent.url,
+  width: parent => parent.width,
+  height: parent => parent.height
 };
 ",
     "force": false,
@@ -948,6 +971,7 @@ import { ExperienceParent } from \\"../Experience\\";
 import { ReviewParent } from \\"../Review\\";
 import { NeighbourhoodParent } from \\"../Neighbourhood\\";
 import { LocationParent } from \\"../Location\\";
+import { VideoParent } from \\"../Video\\";
 import { PictureParent } from \\"../Picture\\";
 import { CityParent } from \\"../City\\";
 import { ExperienceCategoryParent } from \\"../ExperienceCategory\\";
@@ -983,6 +1007,7 @@ export interface TypeMap extends ITypeMap {
   ReviewParent: ReviewParent;
   NeighbourhoodParent: NeighbourhoodParent;
   LocationParent: LocationParent;
+  VideoParent: VideoParent;
   PictureParent: PictureParent;
   CityParent: CityParent;
   ExperienceCategoryParent: ExperienceCategoryParent;
@@ -1022,6 +1047,7 @@ import { Experience } from \\"./Experience\\";
 import { Review } from \\"./Review\\";
 import { Neighbourhood } from \\"./Neighbourhood\\";
 import { Location } from \\"./Location\\";
+import { Video } from \\"./Video\\";
 import { Picture } from \\"./Picture\\";
 import { City } from \\"./City\\";
 import { ExperienceCategory } from \\"./ExperienceCategory\\";
@@ -1054,6 +1080,7 @@ export const resolvers: IResolvers<TypeMap> = {
   Review,
   Neighbourhood,
   Location,
+  Video,
   Picture,
   City,
   ExperienceCategory,

--- a/src/tests/scaffold-typescript/large-schema.test.ts
+++ b/src/tests/scaffold-typescript/large-schema.test.ts
@@ -14,5 +14,5 @@ test("large schema", async () => {
     generator: "scaffold-typescript"
   });
   expect(code).toMatchSnapshot();
-  expect(code.length).toBe(33);
+  expect(code.length).toBe(34);
 });

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -2,7 +2,11 @@
 
 exports[`basic enum 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -88,7 +92,11 @@ export interface IResolvers<T extends ITypeMap> {
 
 exports[`basic input 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -164,7 +172,11 @@ export interface IResolvers<T extends ITypeMap> {
 
 exports[`basic interface 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -189,7 +201,7 @@ export namespace MediaResolvers {
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Interface<T extends ITypeMap> {
     id: (
       parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
       args: {},
@@ -202,6 +214,17 @@ export namespace MediaResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
+  }
+
+  export interface Type<T extends ITypeMap> {
+    __resolveType?: GraphQLTypeResolver<
+      T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      T[\\"Context\\"]
+    >;
+    __isTypeOf?: GraphQLIsTypeOfFn<
+      T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      T[\\"Context\\"]
+    >;
   }
 }
 
@@ -227,7 +250,8 @@ export namespace VideoResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> extends MediaResolvers.Type<T> {
+  export interface Type<T extends ITypeMap>
+    extends MediaResolvers.Interface<T> {
     id: (
       parent: T[\\"VideoParent\\"],
       args: {},
@@ -278,7 +302,8 @@ export namespace PictureResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> extends MediaResolvers.Type<T> {
+  export interface Type<T extends ITypeMap>
+    extends MediaResolvers.Interface<T> {
     id: (
       parent: T[\\"PictureParent\\"],
       args: {},
@@ -414,13 +439,18 @@ export interface IResolvers<T extends ITypeMap> {
   Video: VideoResolvers.Type<T>;
   Picture: PictureResolvers.Type<T>;
   Home: HomeResolvers.Type<T>;
+  Media?: MediaResolvers.Type<T>;
 }
 "
 `;
 
 exports[`basic scalar 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -483,7 +513,11 @@ export interface IResolvers<T extends ITypeMap> {
 
 exports[`basic schema 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -722,7 +756,11 @@ export interface IResolvers<T extends ITypeMap> {
 
 exports[`basic union 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -851,10 +851,24 @@ export namespace ProfessorResolvers {
   }
 }
 
+export namespace UserTypeResolvers {
+  export interface Type<T extends ITypeMap> {
+    __resolveType?: GraphQLTypeResolver<
+      T[\\"StudentParent\\"] | T[\\"ProfessorParent\\"],
+      T[\\"Context\\"]
+    >;
+    __isTypeOf?: GraphQLIsTypeOfFn<
+      T[\\"StudentParent\\"] | T[\\"ProfessorParent\\"],
+      T[\\"Context\\"]
+    >;
+  }
+}
+
 export interface IResolvers<T extends ITypeMap> {
   User: UserResolvers.Type<T>;
   Student: StudentResolvers.Type<T>;
   Professor: ProfessorResolvers.Type<T>;
+  UserType?: UserTypeResolvers.Type<T>;
 }
 "
 `;

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -227,7 +227,7 @@ export namespace VideoResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap> extends MediaResolvers.Type<T> {
     id: (
       parent: T[\\"VideoParent\\"],
       args: {},
@@ -278,7 +278,7 @@ export namespace PictureResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap> extends MediaResolvers.Type<T> {
     id: (
       parent: T[\\"PictureParent\\"],
       args: {},

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -162,6 +162,231 @@ export interface IResolvers<T extends ITypeMap> {
 "
 `;
 
+exports[`basic interface 1`] = `
+"/* DO NOT EDIT! */
+import { GraphQLResolveInfo } from \\"graphql\\";
+
+export interface ITypeMap {
+  Context: any;
+
+  VideoParent: any;
+  PictureParent: any;
+  HomeParent: any;
+}
+
+export namespace VideoResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type NameResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type DurationResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export interface Type<T extends ITypeMap> {
+    id: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    name: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    duration: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+  }
+}
+
+export namespace PictureResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type UrlResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type WidthResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export type HeightResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export interface Type<T extends ITypeMap> {
+    id: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    url: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    width: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+    height: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+  }
+}
+
+export namespace HomeResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type NameResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | null | Promise<string | null>;
+
+  export type DescriptionResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type NumRatingsResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export type AvgRatingResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | null | Promise<number | null>;
+
+  export interface ArgsMedia<T extends ITypeMap> {
+    first: number | null;
+  }
+
+  export type MediaResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: ArgsMedia<T>,
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) =>
+    | Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>
+    | Promise<Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>>;
+
+  export type PerNightResolver<T extends ITypeMap> = (
+    parent: T[\\"HomeParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export interface Type<T extends ITypeMap> {
+    id: (
+      parent: T[\\"HomeParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    name: (
+      parent: T[\\"HomeParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | null | Promise<string | null>;
+    description: (
+      parent: T[\\"HomeParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    numRatings: (
+      parent: T[\\"HomeParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+    avgRating: (
+      parent: T[\\"HomeParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | null | Promise<number | null>;
+    media: (
+      parent: T[\\"HomeParent\\"],
+      args: ArgsMedia<T>,
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) =>
+      | Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>
+      | Promise<Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>>;
+    perNight: (
+      parent: T[\\"HomeParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+  }
+}
+
+export interface IResolvers<T extends ITypeMap> {
+  Video: VideoResolvers.Type<T>;
+  Picture: PictureResolvers.Type<T>;
+  Home: HomeResolvers.Type<T>;
+}
+"
+`;
+
 exports[`basic scalar 1`] = `
 "/* DO NOT EDIT! */
 import { GraphQLResolveInfo } from \\"graphql\\";

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -174,6 +174,37 @@ export interface ITypeMap {
   HomeParent: any;
 }
 
+export namespace MediaResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type UrlResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export interface Type<T extends ITypeMap> {
+    id: (
+      parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    url: (
+      parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+  }
+}
+
 export namespace VideoResolvers {
   export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"VideoParent\\"],

--- a/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -2,7 +2,11 @@
 
 exports[`large schema 1`] = `
 "/* DO NOT EDIT! */
-import { GraphQLResolveInfo } from \\"graphql\\";
+import {
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+  GraphQLIsTypeOfFn
+} from \\"graphql\\";
 
 export interface ITypeMap {
   Context: any;
@@ -38,6 +42,48 @@ export interface ITypeMap {
   PoliciesParent: any;
   HouseRulesParent: any;
   AmenitiesParent: any;
+}
+
+export namespace MediaResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type UrlResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export interface Interface<T extends ITypeMap> {
+    id: (
+      parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    url: (
+      parent: T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+  }
+
+  export interface Type<T extends ITypeMap> {
+    __resolveType?: GraphQLTypeResolver<
+      T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      T[\\"Context\\"]
+    >;
+    __isTypeOf?: GraphQLIsTypeOfFn<
+      T[\\"VideoParent\\"] | T[\\"PictureParent\\"],
+      T[\\"Context\\"]
+    >;
+  }
 }
 
 export namespace QueryResolvers {
@@ -1010,7 +1056,8 @@ export namespace VideoResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap>
+    extends MediaResolvers.Interface<T> {
     id: (
       parent: T[\\"VideoParent\\"],
       args: {},
@@ -1061,7 +1108,8 @@ export namespace PictureResolvers {
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export interface Type<T extends ITypeMap> {
+  export interface Type<T extends ITypeMap>
+    extends MediaResolvers.Interface<T> {
     id: (
       parent: T[\\"PictureParent\\"],
       args: {},
@@ -3413,6 +3461,7 @@ export interface IResolvers<T extends ITypeMap> {
   Policies: PoliciesResolvers.Type<T>;
   HouseRules: HouseRulesResolvers.Type<T>;
   Amenities: AmenitiesResolvers.Type<T>;
+  Media?: MediaResolvers.Type<T>;
 }
 "
 `;

--- a/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -19,6 +19,7 @@ export interface ITypeMap {
   ReviewParent: any;
   NeighbourhoodParent: any;
   LocationParent: any;
+  VideoParent: any;
   PictureParent: any;
   CityParent: any;
   ExperienceCategoryParent: any;
@@ -394,16 +395,18 @@ export namespace HomeResolvers {
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export interface ArgsPictures<T extends ITypeMap> {
+  export interface ArgsMedia<T extends ITypeMap> {
     first: number | null;
   }
 
-  export type PicturesResolver<T extends ITypeMap> = (
+  export type MediaResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
-    args: ArgsPictures<T>,
+    args: ArgsMedia<T>,
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
-  ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
+  ) =>
+    | Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>
+    | Promise<Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>>;
 
   export type PerNightResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
@@ -443,12 +446,14 @@ export namespace HomeResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
-    pictures: (
+    media: (
       parent: T[\\"HomeParent\\"],
-      args: ArgsPictures<T>,
+      args: ArgsMedia<T>,
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
-    ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
+    ) =>
+      | Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>
+      | Promise<Array<T[\\"VideoParent\\"] | T[\\"PictureParent\\"]>>;
     perNight: (
       parent: T[\\"HomeParent\\"],
       args: {},
@@ -983,6 +988,50 @@ export namespace LocationResolvers {
   }
 }
 
+export namespace VideoResolvers {
+  export type IdResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type NameResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type DurationResolver<T extends ITypeMap> = (
+    parent: T[\\"VideoParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export interface Type<T extends ITypeMap> {
+    id: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    name: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+    duration: (
+      parent: T[\\"VideoParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+  }
+}
+
 export namespace PictureResolvers {
   export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PictureParent\\"],
@@ -998,6 +1047,20 @@ export namespace PictureResolvers {
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
+  export type WidthResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
+  export type HeightResolver<T extends ITypeMap> = (
+    parent: T[\\"PictureParent\\"],
+    args: {},
+    ctx: T[\\"Context\\"],
+    info: GraphQLResolveInfo
+  ) => number | Promise<number>;
+
   export interface Type<T extends ITypeMap> {
     id: (
       parent: T[\\"PictureParent\\"],
@@ -1011,6 +1074,18 @@ export namespace PictureResolvers {
       ctx: T[\\"Context\\"],
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
+    width: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
+    height: (
+      parent: T[\\"PictureParent\\"],
+      args: {},
+      ctx: T[\\"Context\\"],
+      info: GraphQLResolveInfo
+    ) => number | Promise<number>;
   }
 }
 
@@ -3319,6 +3394,7 @@ export interface IResolvers<T extends ITypeMap> {
   Review: ReviewResolvers.Type<T>;
   Neighbourhood: NeighbourhoodResolvers.Type<T>;
   Location: LocationResolvers.Type<T>;
+  Video: VideoResolvers.Type<T>;
   Picture: PictureResolvers.Type<T>;
   City: CityResolvers.Type<T>;
   ExperienceCategory: ExperienceCategoryResolvers.Type<T>;

--- a/src/tests/typescript/basic.test.ts
+++ b/src/tests/typescript/basic.test.ts
@@ -52,3 +52,16 @@ test("basic input", async () => {
   const code = generateCode({ schema: parsedSchema });
   expect(code).toMatchSnapshot();
 });
+
+test("basic interface", async () => {
+  const schema = fs.readFileSync(
+    join(__dirname, "../fixtures/interface.graphql"),
+    "utf-8"
+  );
+  const parsedSchema = parse(schema);
+  const code = generateCode({ schema: parsedSchema });
+
+  fs.writeFileSync('./resolvers.ts', code)
+
+  expect(code).toMatchSnapshot();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",
     "outDir": "dist",
     "sourceMap": true,
-    "lib": ["es2015", "esnext.asynciterable"],
+    "lib": ["es2016", "esnext.asynciterable"],
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true


### PR DESCRIPTION
This PR implements generating resolvers for GraphQL interfaces and union types.

It's a rough version, but everything seems to work fine, so maybe there's only some tidying up to do.