### PR TITLE
Add index types for compatibility with graphql-tools

### DIFF
--- a/packages/graphqlgen/src/generators/ts-generator.ts
+++ b/packages/graphqlgen/src/generators/ts-generator.ts
@@ -303,8 +303,10 @@ function renderResolverTypeInterface(
   modelMap: ModelMap,
   context?: ContextDefinition,
 ): string {
+  // TODO add types for key and value
   return `
   export interface Type {
+    [key: string]: any;
     ${type.fields
       .map(field =>
         renderResolverTypeInterfaceFunction(field, type, modelMap, context),
@@ -336,12 +338,17 @@ function renderResolverTypeInterfaceFunction(
 }
 
 function renderResolvers(args: GenerateArgs): string {
+  const types = args.types.filter(type => type.type.isObject)
+  const unionOfTypes = types
+    .map(function(type) {
+      return type.name + 'Resolvers.Type'
+    })
+    .join(' | ')
+  // TODO add enum type for the key
   return `
 export interface Resolvers {
-  ${args.types
-    .filter(type => type.type.isObject)
-    .map(type => `${type.name}: ${type.name}Resolvers.Type`)
-    .join(os.EOL)}
+  [key: string]: ${unionOfTypes};
+  ${types.map(type => `${type.name}: ${type.name}Resolvers.Type`).join(os.EOL)}
 }
   `
 }

--- a/packages/graphqlgen/src/tests/scaffold-typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/src/tests/scaffold-typescript/__snapshots__/basic.test.ts.snap
@@ -118,6 +118,8 @@ export namespace QueryResolvers {
   ) => boolean | Promise<boolean>;
 
   export interface Type {
+    [key: string]: any;
+
     id: (
       parent: {},
       args: {},
@@ -232,6 +234,8 @@ export namespace NumberResolvers {
   ) => number | null | Promise<number | null>;
 
   export interface Type {
+    [key: string]: any;
+
     id: (
       parent: Number,
       args: {},
@@ -249,6 +253,7 @@ export namespace NumberResolvers {
 }
 
 export interface Resolvers {
+  [key: string]: QueryResolvers.Type | NumberResolvers.Type;
   Query: QueryResolvers.Type;
   Number: NumberResolvers.Type;
 }


### PR DESCRIPTION
I have checked the issue https://github.com/prisma/graphqlgen/issues/124 Right now graphql-tools is complaining because index signatures are missing. To make it type-safe, you probably need to generate enum types for keys and, instead of any, to use union types. This PR makes it compatible with graphql-tools.