### PR TITLE
Replace \ with / in path-helpers

### DIFF
--- a/packages/graphqlgen/src/path-helpers.ts
+++ b/packages/graphqlgen/src/path-helpers.ts
@@ -35,7 +35,7 @@ export function getAbsoluteFilePath(
       throw new Error(`${absolutePath} has to be a ${extName} file`)
     }
 
-    return absolutePath
+    return absolutePath.replace(/\\/g, '/')
   }
 
   const indexPath = path.join(absolutePath, 'index' + extName)
@@ -45,7 +45,7 @@ export function getAbsoluteFilePath(
     )
   }
 
-  return indexPath
+  return indexPath.replace(/\\/g, '/')
 }
 
 // TODO write test cases
@@ -64,6 +64,9 @@ export function getImportPathRelativeToOutput(
 
   // remove /index
   relativePath = relativePath.replace(/\/index$/, '')
+
+  // replace \ with /
+  relativePath = relativePath.replace(/\\/g, '/')
 
   return relativePath
 }


### PR DESCRIPTION
Fixes: https://github.com/prisma/graphqlgen/issues/207

On windows all import paths have `\` as the path separator, which is incorrect syntax. I have changed `path-helpers.ts` to return all paths with `\`s replaced with `/`s.