### PR TITLE
Use GraphQLSchema to speed up schema parsing.

### DIFF
--- a/packages/graphqlgen/src/index.ts
+++ b/packages/graphqlgen/src/index.ts
@@ -7,13 +7,8 @@ import * as mkdirp from 'mkdirp'
 import * as prettier from 'prettier'
 import * as rimraf from 'rimraf'
 import * as yargs from 'yargs'
-import { DocumentNode } from 'graphql'
 import { GraphQLGenDefinition, Language } from 'graphqlgen-json-schema'
-import {
-  extractGraphQLTypes,
-  extractGraphQLEnums,
-  extractGraphQLUnions,
-} from './source-helper'
+import { GraphQLTypes } from './source-helper'
 import {
   getImportPathRelativeToOutput,
   getAbsoluteFilePath,
@@ -40,7 +35,7 @@ import { parseConfig, parseContext, parseSchema, parseModels } from './parse'
 import { validateConfig } from './validation'
 
 export type GenerateCodeArgs = {
-  schema: DocumentNode
+  schema: GraphQLTypes
   config: GraphQLGenDefinition
   modelMap: ModelMap
   prettify?: boolean
@@ -112,10 +107,9 @@ function generateResolvers(
 export function generateCode(
   generateCodeArgs: GenerateCodeArgs,
 ): { generatedTypes: string; generatedResolvers: CodeFileLike[] } {
+  const { schema } = generateCodeArgs
   const generateArgs: GenerateArgs = {
-    types: extractGraphQLTypes(generateCodeArgs.schema!),
-    enums: extractGraphQLEnums(generateCodeArgs.schema!),
-    unions: extractGraphQLUnions(generateCodeArgs.schema!),
+    ...schema,
     context: parseContext(
       generateCodeArgs.config.context,
       generateCodeArgs.config.output,

--- a/packages/graphqlgen/src/validation.ts
+++ b/packages/graphqlgen/src/validation.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk'
 import { existsSync } from 'fs'
-import { DocumentNode } from 'graphql'
 import {
   GraphQLGenDefinition,
   Language,
@@ -15,7 +14,7 @@ import {
   outputModelFilesNotFound,
   outputWrongSyntaxFiles,
 } from './output'
-import { extractGraphQLTypesWithoutRootsAndInputs } from './source-helper'
+import { extractGraphQLTypesWithoutRootsAndInputs, GraphQLTypes } from './source-helper'
 import { normalizeFilePath } from './utils'
 import { replaceVariablesInString, getPath, getDefaultName } from './parse'
 
@@ -35,7 +34,7 @@ export type ValidatedDefinition = {
 
 export function validateConfig(
   config: GraphQLGenDefinition,
-  schema: DocumentNode,
+  schema: GraphQLTypes,
 ): boolean {
   const language = config.language
 
@@ -102,7 +101,7 @@ function validateContext(
 
 function validateModels(
   models: Models,
-  schema: DocumentNode,
+  schema: GraphQLTypes,
   language: Language,
 ): boolean {
   const filePaths = !!models.files
@@ -168,7 +167,7 @@ function testValidatedDefinitions(
 }
 
 function validateSchemaToModelMapping(
-  schema: DocumentNode,
+  schema: GraphQLTypes,
   validatedOverriddenModels: ValidatedDefinition[],
   files: File[],
 ): boolean {


### PR DESCRIPTION
Visiting DocumentNode directly was fairly tedious because there was
no map-based access to the types, so each time we wanted to look
up the type of a field/argument/etc., we had to start all over
at the top and rescan the AST (specifically extractTypeDefinition).

This adds a new GraphQLTypes to source-helper that is the trio
of types/unions/enums that is: a) built quickly via the graphql's
buildASTSchema, and b) built once up-front in parse.ts
and then replaces DocumentNode as what we pass around as our
current schema.