### PR TITLE
Updated README - Clarified npm / yarn instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,27 @@ Programming in type-safe environments provides a lot of benefits and gives you c
 
 ### Start from scratch
 
-Bootstrap a GraphQL server based with a ready-made `graphqlen` setup: 
+Bootstrap a GraphQL server based with a ready-made `graphqlen` setup then
+start the server:
 
+*With `npm`*
+```bash
+npm init graphqlgen my-app
+cd my-app
+npm start
 ```
-npm init graphqlgen ./my-app
-```
+*Note: `npm init` requires npm version >= 6.2.0*
 
-Then start the server:
+or
 
-```
+*With `yarn`*
+
+```bash
+yarn create graphqlgen my-app
 cd my-app
 yarn start
 ```
+*Note: `yarn create` requires yarn version >= 0.24.2*
 
 After updating the GraphQL schema in `.my-app/src/schema.graphql`, execute the `graphqlgen` CLI to update all resolvers:
 
@@ -55,10 +64,16 @@ graphqlgen
 
 #### Install
 
-You can install the `graphqlgen` CLI with the following command:
+You can install the `graphqlgen` CLI with either of the following commands:
 
 ```bash
 npm install -g graphqlgen
+```
+
+or
+
+```bash
+yarn global add graphqlgen
 ```
 
 #### Usage


### PR DESCRIPTION
This PR attempts to clarify the commands in the README used for bootstrapping and the client install via npm or yarn.  It also explicitly states the version of npm and yarn that support the init/create commands required for bootstrapping.  Older versions of npm (e.g. npm v3.5.2 on Ubuntu 18.04) are particularly problematic because they support the init command, but not in a way that can be used with these steps.  This would leave unaware users with a decent roadblock at the start an no obvious error message to work with.

These versions may need to be bumped up depending on other app requirements that I am not familiar with.