### PR TITLE
Add missing input types

### DIFF
--- a/packages/graphqlgen/src/generators/common.ts
+++ b/packages/graphqlgen/src/generators/common.ts
@@ -229,7 +229,7 @@ function deepResolveInputTypes(
   const type = inputTypesMap[typeName]
   if (type) {
     const childTypes = type.fields
-      .filter(t => t.type.isInput && !seen[type.name])
+      .filter(t => t.type.isInput && !seen[t.type.name])
       .map(t => t.type.name)
       .map(name =>
         deepResolveInputTypes(inputTypesMap, name, { ...seen, [name]: true }),

--- a/packages/graphqlgen/src/tests/fixtures/input/schema.graphql
+++ b/packages/graphqlgen/src/tests/fixtures/input/schema.graphql
@@ -14,6 +14,12 @@ input AddMemberData {
 input ProfileData {
   firstName: String
   lastName: String
+  photo: Photo
+}
+
+input Photo {
+  title: String!
+  url: String!
 }
 
 input PhoneData {

--- a/packages/graphqlgen/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -181,6 +181,11 @@ export namespace MutationResolvers {
   export interface ProfileData {
     firstName: string | null;
     lastName: string | null;
+    photo: Photo | null;
+  }
+  export interface Photo {
+    title: string;
+    url: string;
   }
   export interface PhoneData {
     number: string;


### PR DESCRIPTION
Hello!

Generated typings are invalid when input type has field that is also input type. This PR adds input types to `typeToInputTypeAssociation` recusively.