### PR TITLE
do not use `never` for empty arguments or parents

### DIFF
--- a/packages/graphqlgen/src/generators/ts-generator.ts
+++ b/packages/graphqlgen/src/generators/ts-generator.ts
@@ -241,9 +241,9 @@ function renderResolverFunctionInterface(
   const resolverName = `${upperFirst(field.name)}Resolver`
   const resolverDefinition = `
   (
-    parent: ${getModelName(type.type as any, modelMap, 'never')},
+    parent: ${getModelName(type.type as any, modelMap, 'undefined')},
     args: ${
-      field.arguments.length > 0 ? `Args${upperFirst(field.name)}` : 'never'
+      field.arguments.length > 0 ? `Args${upperFirst(field.name)}` : '{}'
     },
     ctx: ${getContextName(context)},
     info: GraphQLResolveInfo,
@@ -289,9 +289,9 @@ function renderResolverTypeInterfaceFunction(
 ): string {
   const resolverDefinition = `
   (
-    parent: ${getModelName(type.type as any, modelMap, 'never')},
+    parent: ${getModelName(type.type as any, modelMap, 'undefined')},
     args: ${
-      field.arguments.length > 0 ? `Args${upperFirst(field.name)}` : 'never'
+      field.arguments.length > 0 ? `Args${upperFirst(field.name)}` : '{}'
     },
     ctx: ${getContextName(context)},
     info: GraphQLResolveInfo,

--- a/packages/graphqlgen/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -19,7 +19,7 @@ export namespace QueryResolvers {
   }
 
   export type CreateUserResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsCreateUser,
     ctx: Context,
     info: GraphQLResolveInfo
@@ -27,7 +27,7 @@ export namespace QueryResolvers {
 
   export interface Type {
     createUser: (
-      parent: never,
+      parent: undefined,
       args: ArgsCreateUser,
       ctx: Context,
       info: GraphQLResolveInfo
@@ -44,28 +44,28 @@ export namespace UserResolvers {
 
   export type IdResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type EnumAnnotationResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => EnumAnnotation | Promise<EnumAnnotation>;
 
   export type EnumAsUnionTypeResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => EnumAsUnionType | Promise<EnumAsUnionType>;
@@ -73,28 +73,28 @@ export namespace UserResolvers {
   export interface Type {
     id: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     enumAnnotation: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => EnumAnnotation | Promise<EnumAnnotation>;
 
     enumAsUnionType: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => EnumAsUnionType | Promise<EnumAsUnionType>;
@@ -202,14 +202,14 @@ export namespace MutationResolvers {
   }
 
   export type AddMemberResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsAddMember,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => AddMemberPayload | Promise<AddMemberPayload>;
 
   export type AddMembersResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsAddMembers,
     ctx: Context,
     info: GraphQLResolveInfo
@@ -217,14 +217,14 @@ export namespace MutationResolvers {
 
   export interface Type {
     addMember: (
-      parent: never,
+      parent: undefined,
       args: ArgsAddMember,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => AddMemberPayload | Promise<AddMemberPayload>;
 
     addMembers: (
-      parent: never,
+      parent: undefined,
       args: ArgsAddMembers,
       ctx: Context,
       info: GraphQLResolveInfo
@@ -239,14 +239,14 @@ export namespace AddMemberPayloadResolvers {
 
   export type NewUserIdResolver = (
     parent: AddMemberPayload,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type ExistingUserInviteSentResolver = (
     parent: AddMemberPayload,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
@@ -254,14 +254,14 @@ export namespace AddMemberPayloadResolvers {
   export interface Type {
     newUserId: (
       parent: AddMemberPayload,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     existingUserInviteSent: (
       parent: AddMemberPayload,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
@@ -353,7 +353,7 @@ export namespace MutationResolvers {
   }
 
   export type AddMemberResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsAddMember,
     ctx: Context,
     info: GraphQLResolveInfo
@@ -361,7 +361,7 @@ export namespace MutationResolvers {
 
   export interface Type {
     addMember: (
-      parent: never,
+      parent: undefined,
       args: ArgsAddMember,
       ctx: Context,
       info: GraphQLResolveInfo
@@ -376,7 +376,7 @@ export namespace AddMemberPayloadResolvers {
 
   export type JsonResolver = (
     parent: AddMemberPayload,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
@@ -384,7 +384,7 @@ export namespace AddMemberPayloadResolvers {
   export interface Type {
     json: (
       parent: AddMemberPayload,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
@@ -476,91 +476,91 @@ export namespace QueryResolvers {
   }
 
   export type IdResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type Custom_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Number | Promise<Number>;
 
   export type Custom_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Number | null | Promise<Number | null>;
 
   export type Custom_array_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Number[] | null | Promise<Number[] | null>;
 
   export type Custom_array_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Number[] | Promise<Number[]>;
 
   export type Custom_with_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsCustom_with_arg,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Number | Promise<Number>;
 
   export type Custom_with_custom_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsCustom_with_custom_arg,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Number | Promise<Number>;
 
   export type Scalar_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type Scalar_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type Scalar_array_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean[] | null | Promise<boolean[] | null>;
 
   export type Scalar_array_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean[] | Promise<boolean[]>;
 
   export type Scalar_with_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsScalar_with_arg,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type Scalar_with_custom_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsScalar_with_custom_arg,
     ctx: Context,
     info: GraphQLResolveInfo
@@ -568,91 +568,91 @@ export namespace QueryResolvers {
 
   export interface Type {
     id: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     custom_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Number | Promise<Number>;
 
     custom_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Number | null | Promise<Number | null>;
 
     custom_array_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Number[] | null | Promise<Number[] | null>;
 
     custom_array_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Number[] | Promise<Number[]>;
 
     custom_with_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsCustom_with_arg,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Number | Promise<Number>;
 
     custom_with_custom_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsCustom_with_custom_arg,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Number | Promise<Number>;
 
     scalar_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     scalar_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     scalar_array_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean[] | null | Promise<boolean[] | null>;
 
     scalar_array_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean[] | Promise<boolean[]>;
 
     scalar_with_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsScalar_with_arg,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     scalar_with_custom_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsScalar_with_custom_arg,
       ctx: Context,
       info: GraphQLResolveInfo
@@ -668,14 +668,14 @@ export namespace NumberResolvers {
 
   export type IdResolver = (
     parent: Number,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type ValueResolver = (
     parent: Number,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
@@ -683,14 +683,14 @@ export namespace NumberResolvers {
   export interface Type {
     id: (
       parent: Number,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     value: (
       parent: Number,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
@@ -806,21 +806,21 @@ export namespace UserResolvers {
 
   export type IdResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type TypeResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => {} | Promise<{}>;
@@ -828,21 +828,21 @@ export namespace UserResolvers {
   export interface Type {
     id: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     type: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => {} | Promise<{}>;
@@ -856,7 +856,7 @@ export namespace StudentResolvers {
 
   export type AgeResolver = (
     parent: Student,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -864,7 +864,7 @@ export namespace StudentResolvers {
   export interface Type {
     age: (
       parent: Student,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -878,7 +878,7 @@ export namespace ProfessorResolvers {
 
   export type DegreeResolver = (
     parent: Professor,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
@@ -886,7 +886,7 @@ export namespace ProfessorResolvers {
   export interface Type {
     degree: (
       parent: Professor,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
@@ -979,16 +979,16 @@ export namespace QueryResolvers {
   export const defaultResolvers = {};
 
   export type CreateUserResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | null | Promise<User | null>;
 
   export interface Type {
     createUser: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | null | Promise<User | null>;
@@ -1002,7 +1002,7 @@ export namespace UserResolvers {
 
   export type IdResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -1010,7 +1010,7 @@ export namespace UserResolvers {
   export interface Type {
     id: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -1102,91 +1102,91 @@ export namespace QueryResolvers {
   }
 
   export type IdResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type Custom_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NumberNode | Promise<NumberNode>;
 
   export type Custom_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NumberNode | null | Promise<NumberNode | null>;
 
   export type Custom_array_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NumberNode[] | null | Promise<NumberNode[] | null>;
 
   export type Custom_array_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NumberNode[] | Promise<NumberNode[]>;
 
   export type Custom_with_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsCustom_with_arg,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NumberNode | Promise<NumberNode>;
 
   export type Custom_with_custom_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsCustom_with_custom_arg,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NumberNode | Promise<NumberNode>;
 
   export type Scalar_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type Scalar_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type Scalar_array_nullableResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean[] | null | Promise<boolean[] | null>;
 
   export type Scalar_array_requiredResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean[] | Promise<boolean[]>;
 
   export type Scalar_with_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsScalar_with_arg,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type Scalar_with_custom_argResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsScalar_with_custom_arg,
     ctx: Context,
     info: GraphQLResolveInfo
@@ -1194,91 +1194,91 @@ export namespace QueryResolvers {
 
   export interface Type {
     id: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     custom_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NumberNode | Promise<NumberNode>;
 
     custom_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NumberNode | null | Promise<NumberNode | null>;
 
     custom_array_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NumberNode[] | null | Promise<NumberNode[] | null>;
 
     custom_array_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NumberNode[] | Promise<NumberNode[]>;
 
     custom_with_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsCustom_with_arg,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NumberNode | Promise<NumberNode>;
 
     custom_with_custom_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsCustom_with_custom_arg,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NumberNode | Promise<NumberNode>;
 
     scalar_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     scalar_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     scalar_array_nullable: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean[] | null | Promise<boolean[] | null>;
 
     scalar_array_required: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean[] | Promise<boolean[]>;
 
     scalar_with_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsScalar_with_arg,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     scalar_with_custom_arg: (
-      parent: never,
+      parent: undefined,
       args: ArgsScalar_with_custom_arg,
       ctx: Context,
       info: GraphQLResolveInfo
@@ -1294,14 +1294,14 @@ export namespace NumberResolvers {
 
   export type IdResolver = (
     parent: NumberNode,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type ValueResolver = (
     parent: NumberNode,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
@@ -1309,14 +1309,14 @@ export namespace NumberResolvers {
   export interface Type {
     id: (
       parent: NumberNode,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     value: (
       parent: NumberNode,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
@@ -1429,14 +1429,14 @@ export namespace SubscriptionResolvers {
 
   export type SubscribeToUserResolver = {
     subscribe: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => AsyncIterator<User> | Promise<AsyncIterator<User>>;
     resolve?: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
@@ -1445,14 +1445,14 @@ export namespace SubscriptionResolvers {
   export interface Type {
     subscribeToUser: {
       subscribe: (
-        parent: never,
-        args: never,
+        parent: undefined,
+        args: {},
         ctx: Context,
         info: GraphQLResolveInfo
       ) => AsyncIterator<User> | Promise<AsyncIterator<User>>;
       resolve?: (
-        parent: never,
-        args: never,
+        parent: undefined,
+        args: {},
         ctx: Context,
         info: GraphQLResolveInfo
       ) => User | Promise<User>;
@@ -1467,7 +1467,7 @@ export namespace UserResolvers {
 
   export type NameResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -1475,7 +1475,7 @@ export namespace UserResolvers {
   export interface Type {
     name: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;

--- a/packages/graphqlgen/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/packages/graphqlgen/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -67,114 +67,114 @@ export namespace QueryResolvers {
   }
 
   export type TopExperiencesResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Experience[] | Promise<Experience[]>;
 
   export type TopHomesResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Home[] | Promise<Home[]>;
 
   export type HomesInPriceRangeResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsHomesInPriceRange,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Home[] | Promise<Home[]>;
 
   export type TopReservationsResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Reservation[] | Promise<Reservation[]>;
 
   export type FeaturedDestinationsResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Neighbourhood[] | Promise<Neighbourhood[]>;
 
   export type ExperiencesByCityResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsExperiencesByCity,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
 
   export type ViewerResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Viewer | null | Promise<Viewer | null>;
 
   export type MyLocationResolver = (
-    parent: never,
-    args: never,
+    parent: undefined,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Location | null | Promise<Location | null>;
 
   export interface Type {
     topExperiences: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Experience[] | Promise<Experience[]>;
 
     topHomes: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Home[] | Promise<Home[]>;
 
     homesInPriceRange: (
-      parent: never,
+      parent: undefined,
       args: ArgsHomesInPriceRange,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Home[] | Promise<Home[]>;
 
     topReservations: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Reservation[] | Promise<Reservation[]>;
 
     featuredDestinations: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Neighbourhood[] | Promise<Neighbourhood[]>;
 
     experiencesByCity: (
-      parent: never,
+      parent: undefined,
       args: ArgsExperiencesByCity,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
 
     viewer: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Viewer | null | Promise<Viewer | null>;
 
     myLocation: (
-      parent: never,
-      args: never,
+      parent: undefined,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Location | null | Promise<Location | null>;
@@ -196,56 +196,56 @@ export namespace ExperienceResolvers {
 
   export type IdResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type CategoryResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => ExperienceCategory | null | Promise<ExperienceCategory | null>;
 
   export type TitleResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LocationResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Location | Promise<Location>;
 
   export type PricePerPersonResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type ReviewsResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Review[] | Promise<Review[]>;
 
   export type PreviewResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Picture | Promise<Picture>;
 
   export type PopularityResolver = (
     parent: Experience,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -253,56 +253,56 @@ export namespace ExperienceResolvers {
   export interface Type {
     id: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     category: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => ExperienceCategory | null | Promise<ExperienceCategory | null>;
 
     title: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     location: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Location | Promise<Location>;
 
     pricePerPerson: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     reviews: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Review[] | Promise<Review[]>;
 
     preview: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Picture | Promise<Picture>;
 
     popularity: (
       parent: Experience,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -320,28 +320,28 @@ export namespace ExperienceCategoryResolvers {
 
   export type IdResolver = (
     parent: ExperienceCategory,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type MainColorResolver = (
     parent: ExperienceCategory,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: ExperienceCategory,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type ExperienceResolver = (
     parent: ExperienceCategory,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Experience | null | Promise<Experience | null>;
@@ -349,28 +349,28 @@ export namespace ExperienceCategoryResolvers {
   export interface Type {
     id: (
       parent: ExperienceCategory,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     mainColor: (
       parent: ExperienceCategory,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: ExperienceCategory,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     experience: (
       parent: ExperienceCategory,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Experience | null | Promise<Experience | null>;
@@ -390,35 +390,35 @@ export namespace LocationResolvers {
 
   export type IdResolver = (
     parent: Location,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LatResolver = (
     parent: Location,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type LngResolver = (
     parent: Location,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type AddressResolver = (
     parent: Location,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type DirectionsResolver = (
     parent: Location,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
@@ -426,35 +426,35 @@ export namespace LocationResolvers {
   export interface Type {
     id: (
       parent: Location,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     lat: (
       parent: Location,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     lng: (
       parent: Location,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     address: (
       parent: Location,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     directions: (
       parent: Location,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
@@ -477,70 +477,70 @@ export namespace ReviewResolvers {
 
   export type AccuracyResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CheckInResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CleanlinessResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CommunicationResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CreatedAtResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LocationResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type StarsResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type TextResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type ValueResolver = (
     parent: Review,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -548,70 +548,70 @@ export namespace ReviewResolvers {
   export interface Type {
     accuracy: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     checkIn: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     cleanliness: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     communication: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     createdAt: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     location: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     stars: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     text: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     value: (
       parent: Review,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -626,14 +626,14 @@ export namespace PictureResolvers {
 
   export type IdResolver = (
     parent: Picture,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type UrlResolver = (
     parent: Picture,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -641,14 +641,14 @@ export namespace PictureResolvers {
   export interface Type {
     id: (
       parent: Picture,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     url: (
       parent: Picture,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -673,35 +673,35 @@ export namespace HomeResolvers {
 
   export type IdResolver = (
     parent: Home,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: Home,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type DescriptionResolver = (
     parent: Home,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NumRatingsResolver = (
     parent: Home,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type AvgRatingResolver = (
     parent: Home,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
@@ -715,7 +715,7 @@ export namespace HomeResolvers {
 
   export type PerNightResolver = (
     parent: Home,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -723,35 +723,35 @@ export namespace HomeResolvers {
   export interface Type {
     id: (
       parent: Home,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: Home,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     description: (
       parent: Home,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     numRatings: (
       parent: Home,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     avgRating: (
       parent: Home,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
@@ -765,7 +765,7 @@ export namespace HomeResolvers {
 
     perNight: (
       parent: Home,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -786,56 +786,56 @@ export namespace ReservationResolvers {
 
   export type IdResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type TitleResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type AvgPricePerPersonResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type PicturesResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Picture[] | Promise<Picture[]>;
 
   export type LocationResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Location | Promise<Location>;
 
   export type IsCuratedResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type SlugResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type PopularityResolver = (
     parent: Reservation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -843,56 +843,56 @@ export namespace ReservationResolvers {
   export interface Type {
     id: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     title: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     avgPricePerPerson: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     pictures: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Picture[] | Promise<Picture[]>;
 
     location: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Location | Promise<Location>;
 
     isCurated: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     slug: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     popularity: (
       parent: Reservation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -913,49 +913,49 @@ export namespace NeighbourhoodResolvers {
 
   export type IdResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type SlugResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type HomePreviewResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Picture | null | Promise<Picture | null>;
 
   export type CityResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => City | Promise<City>;
 
   export type FeaturedResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type PopularityResolver = (
     parent: Neighbourhood,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -963,49 +963,49 @@ export namespace NeighbourhoodResolvers {
   export interface Type {
     id: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     slug: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     homePreview: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Picture | null | Promise<Picture | null>;
 
     city: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => City | Promise<City>;
 
     featured: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     popularity: (
       parent: Neighbourhood,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -1020,14 +1020,14 @@ export namespace CityResolvers {
 
   export type IdResolver = (
     parent: City,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: City,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -1035,14 +1035,14 @@ export namespace CityResolvers {
   export interface Type {
     id: (
       parent: City,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: City,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -1057,14 +1057,14 @@ export namespace ExperiencesByCityResolvers {
 
   export type ExperiencesResolver = (
     parent: ExperiencesByCity,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Experience[] | Promise<Experience[]>;
 
   export type CityResolver = (
     parent: ExperiencesByCity,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => City | Promise<City>;
@@ -1072,14 +1072,14 @@ export namespace ExperiencesByCityResolvers {
   export interface Type {
     experiences: (
       parent: ExperiencesByCity,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Experience[] | Promise<Experience[]>;
 
     city: (
       parent: ExperiencesByCity,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => City | Promise<City>;
@@ -1094,14 +1094,14 @@ export namespace ViewerResolvers {
 
   export type MeResolver = (
     parent: Viewer,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | Promise<User>;
 
   export type BookingsResolver = (
     parent: Viewer,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Booking[] | Promise<Booking[]>;
@@ -1109,14 +1109,14 @@ export namespace ViewerResolvers {
   export interface Type {
     me: (
       parent: Viewer,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
 
     bookings: (
       parent: Viewer,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Booking[] | Promise<Booking[]>;
@@ -1149,140 +1149,140 @@ export namespace UserResolvers {
 
   export type BookingsResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Booking[] | Promise<Booking[]>;
 
   export type CreatedAtResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type EmailResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type FirstNameResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type HostingExperiencesResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Experience[] | Promise<Experience[]>;
 
   export type IdResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IsSuperHostResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type LastNameResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LocationResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Location | Promise<Location>;
 
   export type NotificationsResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Notification[] | Promise<Notification[]>;
 
   export type OwnedPlacesResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Place[] | Promise<Place[]>;
 
   export type PaymentAccountResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PaymentAccount[] | Promise<PaymentAccount[]>;
 
   export type PhoneResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type ProfilePictureResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Picture | null | Promise<Picture | null>;
 
   export type ReceivedMessagesResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Message[] | Promise<Message[]>;
 
   export type ResponseRateResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type ResponseTimeResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type SentMessagesResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Message[] | Promise<Message[]>;
 
   export type UpdatedAtResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type TokenResolver = (
     parent: User,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -1290,140 +1290,140 @@ export namespace UserResolvers {
   export interface Type {
     bookings: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Booking[] | Promise<Booking[]>;
 
     createdAt: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     email: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     firstName: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     hostingExperiences: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Experience[] | Promise<Experience[]>;
 
     id: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     isSuperHost: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     lastName: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     location: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Location | Promise<Location>;
 
     notifications: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Notification[] | Promise<Notification[]>;
 
     ownedPlaces: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Place[] | Promise<Place[]>;
 
     paymentAccount: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PaymentAccount[] | Promise<PaymentAccount[]>;
 
     phone: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     profilePicture: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Picture | null | Promise<Picture | null>;
 
     receivedMessages: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Message[] | Promise<Message[]>;
 
     responseRate: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     responseTime: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     sentMessages: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Message[] | Promise<Message[]>;
 
     updatedAt: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     token: (
       parent: User,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -1443,49 +1443,49 @@ export namespace BookingResolvers {
 
   export type IdResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type CreatedAtResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type BookeeResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | Promise<User>;
 
   export type PlaceResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Place | Promise<Place>;
 
   export type StartDateResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type EndDateResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type PaymentResolver = (
     parent: Booking,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Payment | Promise<Payment>;
@@ -1493,49 +1493,49 @@ export namespace BookingResolvers {
   export interface Type {
     id: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     createdAt: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     bookee: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
 
     place: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Place | Promise<Place>;
 
     startDate: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     endDate: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     payment: (
       parent: Booking,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Payment | Promise<Payment>;
@@ -1573,154 +1573,154 @@ export namespace PlaceResolvers {
 
   export type IdResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type NameResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type SizeResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>;
 
   export type ShortDescriptionResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type DescriptionResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type SlugResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type MaxGuestsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type NumBedroomsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type NumBedsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type NumBathsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type ReviewsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Review[] | Promise<Review[]>;
 
   export type AmenitiesResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Amenities | Promise<Amenities>;
 
   export type HostResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | Promise<User>;
 
   export type PricingResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Pricing | Promise<Pricing>;
 
   export type LocationResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Location | Promise<Location>;
 
   export type ViewsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PlaceViews | Promise<PlaceViews>;
 
   export type GuestRequirementsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => GuestRequirements | null | Promise<GuestRequirements | null>;
 
   export type PoliciesResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Policies | null | Promise<Policies | null>;
 
   export type HouseRulesResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => HouseRules | null | Promise<HouseRules | null>;
 
   export type BookingsResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Booking[] | Promise<Booking[]>;
 
   export type PicturesResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Picture[] | Promise<Picture[]>;
 
   export type PopularityResolver = (
     parent: Place,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -1728,154 +1728,154 @@ export namespace PlaceResolvers {
   export interface Type {
     id: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     name: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     size: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>;
 
     shortDescription: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     description: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     slug: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     maxGuests: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     numBedrooms: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     numBeds: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     numBaths: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     reviews: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Review[] | Promise<Review[]>;
 
     amenities: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Amenities | Promise<Amenities>;
 
     host: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
 
     pricing: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Pricing | Promise<Pricing>;
 
     location: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Location | Promise<Location>;
 
     views: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PlaceViews | Promise<PlaceViews>;
 
     guestRequirements: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => GuestRequirements | null | Promise<GuestRequirements | null>;
 
     policies: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Policies | null | Promise<Policies | null>;
 
     houseRules: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => HouseRules | null | Promise<HouseRules | null>;
 
     bookings: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Booking[] | Promise<Booking[]>;
 
     pictures: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Picture[] | Promise<Picture[]>;
 
     popularity: (
       parent: Place,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -1933,287 +1933,287 @@ export namespace AmenitiesResolvers {
 
   export type AirConditioningResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type BabyBathResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type BabyMonitorResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type BabysitterRecommendationsResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type BathtubResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type BreakfastResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type BuzzerWirelessIntercomResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type CableTvResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type ChangingTableResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type ChildrensBooksAndToysResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type ChildrensDinnerwareResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type CribResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type DoormanResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type DryerResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type ElevatorResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type EssentialsResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type FamilyKidFriendlyResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type FreeParkingOnPremisesResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type FreeParkingOnStreetResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type GymResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type HairDryerResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type HangersResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type HeatingResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type HotTubResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type IdResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IndoorFireplaceResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type InternetResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type IronResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type KitchenResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type LaptopFriendlyWorkspaceResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type PaidParkingOffPremisesResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type PetsAllowedResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type PoolResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type PrivateEntranceResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type ShampooResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type SmokingAllowedResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type SuitableForEventsResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type TvResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type WasherResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type WheelchairAccessibleResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type WirelessInternetResolver = (
     parent: Amenities,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
@@ -2221,287 +2221,287 @@ export namespace AmenitiesResolvers {
   export interface Type {
     airConditioning: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     babyBath: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     babyMonitor: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     babysitterRecommendations: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     bathtub: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     breakfast: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     buzzerWirelessIntercom: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     cableTv: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     changingTable: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     childrensBooksAndToys: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     childrensDinnerware: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     crib: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     doorman: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     dryer: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     elevator: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     essentials: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     familyKidFriendly: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     freeParkingOnPremises: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     freeParkingOnStreet: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     gym: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     hairDryer: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     hangers: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     heating: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     hotTub: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     id: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     indoorFireplace: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     internet: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     iron: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     kitchen: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     laptopFriendlyWorkspace: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     paidParkingOffPremises: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     petsAllowed: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     pool: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     privateEntrance: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     shampoo: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     smokingAllowed: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     suitableForEvents: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     tv: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     washer: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     wheelchairAccessible: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     wirelessInternet: (
       parent: Amenities,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
@@ -2534,91 +2534,91 @@ export namespace PricingResolvers {
 
   export type AverageMonthlyResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type AverageWeeklyResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type BasePriceResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CleaningFeeResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type CurrencyResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => CURRENCY | null | Promise<CURRENCY | null>;
 
   export type ExtraGuestsResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type IdResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type MonthlyDiscountResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type PerNightResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type SecurityDepositResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type SmartPricingResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type WeekendPricingResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
   export type WeeklyDiscountResolver = (
     parent: Pricing,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
@@ -2626,91 +2626,91 @@ export namespace PricingResolvers {
   export interface Type {
     averageMonthly: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     averageWeekly: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     basePrice: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     cleaningFee: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     currency: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => CURRENCY | null | Promise<CURRENCY | null>;
 
     extraGuests: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     id: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     monthlyDiscount: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     perNight: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     securityDeposit: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     smartPricing: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     weekendPricing: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
 
     weeklyDiscount: (
       parent: Pricing,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | null | Promise<number | null>;
@@ -2725,14 +2725,14 @@ export namespace PlaceViewsResolvers {
 
   export type IdResolver = (
     parent: PlaceViews,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LastWeekResolver = (
     parent: PlaceViews,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -2740,14 +2740,14 @@ export namespace PlaceViewsResolvers {
   export interface Type {
     id: (
       parent: PlaceViews,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     lastWeek: (
       parent: PlaceViews,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -2766,28 +2766,28 @@ export namespace GuestRequirementsResolvers {
 
   export type GovIssuedIdResolver = (
     parent: GuestRequirements,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type GuestTripInformationResolver = (
     parent: GuestRequirements,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
   export type IdResolver = (
     parent: GuestRequirements,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type RecommendationsFromOtherHostsResolver = (
     parent: GuestRequirements,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
@@ -2795,28 +2795,28 @@ export namespace GuestRequirementsResolvers {
   export interface Type {
     govIssuedId: (
       parent: GuestRequirements,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     guestTripInformation: (
       parent: GuestRequirements,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
 
     id: (
       parent: GuestRequirements,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     recommendationsFromOtherHosts: (
       parent: GuestRequirements,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;
@@ -2835,42 +2835,42 @@ export namespace PoliciesResolvers {
 
   export type CheckInEndTimeResolver = (
     parent: Policies,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CheckInStartTimeResolver = (
     parent: Policies,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CheckoutTimeResolver = (
     parent: Policies,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type CreatedAtResolver = (
     parent: Policies,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: Policies,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type UpdatedAtResolver = (
     parent: Policies,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -2878,42 +2878,42 @@ export namespace PoliciesResolvers {
   export interface Type {
     checkInEndTime: (
       parent: Policies,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     checkInStartTime: (
       parent: Policies,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     checkoutTime: (
       parent: Policies,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     createdAt: (
       parent: Policies,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: Policies,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     updatedAt: (
       parent: Policies,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -2947,63 +2947,63 @@ export namespace HouseRulesResolvers {
 
   export type AdditionalRulesResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
   export type CreatedAtResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type PartiesAndEventsAllowedResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type PetsAllowedResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type SmokingAllowedResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type SuitableForChildrenResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type SuitableForInfantsResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
   export type UpdatedAtResolver = (
     parent: HouseRules,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -3011,63 +3011,63 @@ export namespace HouseRulesResolvers {
   export interface Type {
     additionalRules: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | null | Promise<string | null>;
 
     createdAt: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     partiesAndEventsAllowed: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     petsAllowed: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     smokingAllowed: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     suitableForChildren: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     suitableForInfants: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | null | Promise<boolean | null>;
 
     updatedAt: (
       parent: HouseRules,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -3085,35 +3085,35 @@ export namespace PaymentResolvers {
 
   export type BookingResolver = (
     parent: Payment,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Booking | Promise<Booking>;
 
   export type CreatedAtResolver = (
     parent: Payment,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: Payment,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type PaymentMethodResolver = (
     parent: Payment,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PaymentAccount | Promise<PaymentAccount>;
 
   export type ServiceFeeResolver = (
     parent: Payment,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
@@ -3121,35 +3121,35 @@ export namespace PaymentResolvers {
   export interface Type {
     booking: (
       parent: Payment,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Booking | Promise<Booking>;
 
     createdAt: (
       parent: Payment,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: Payment,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     paymentMethod: (
       parent: Payment,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PaymentAccount | Promise<PaymentAccount>;
 
     serviceFee: (
       parent: Payment,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
@@ -3172,49 +3172,49 @@ export namespace PaymentAccountResolvers {
 
   export type IdResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type CreatedAtResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type TypeResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>;
 
   export type UserResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | Promise<User>;
 
   export type PaymentsResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => Payment[] | Promise<Payment[]>;
 
   export type PaypalResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PaypalInformation | null | Promise<PaypalInformation | null>;
 
   export type CreditcardResolver = (
     parent: PaymentAccount,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => CreditCardInformation | null | Promise<CreditCardInformation | null>;
@@ -3222,49 +3222,49 @@ export namespace PaymentAccountResolvers {
   export interface Type {
     id: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     createdAt: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     type: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>;
 
     user: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
 
     payments: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => Payment[] | Promise<Payment[]>;
 
     paypal: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PaypalInformation | null | Promise<PaypalInformation | null>;
 
     creditcard: (
       parent: PaymentAccount,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => CreditCardInformation | null | Promise<CreditCardInformation | null>;
@@ -3281,28 +3281,28 @@ export namespace PaypalInformationResolvers {
 
   export type CreatedAtResolver = (
     parent: PaypalInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type EmailResolver = (
     parent: PaypalInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: PaypalInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type PaymentAccountResolver = (
     parent: PaypalInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PaymentAccount | Promise<PaymentAccount>;
@@ -3310,28 +3310,28 @@ export namespace PaypalInformationResolvers {
   export interface Type {
     createdAt: (
       parent: PaypalInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     email: (
       parent: PaypalInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: PaypalInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     paymentAccount: (
       parent: PaypalInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PaymentAccount | Promise<PaymentAccount>;
@@ -3356,77 +3356,77 @@ export namespace CreditCardInformationResolvers {
 
   export type CardNumberResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type CountryResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type CreatedAtResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type ExpiresOnMonthResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type ExpiresOnYearResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
   export type FirstNameResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LastNameResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type PaymentAccountResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => PaymentAccount | null | Promise<PaymentAccount | null>;
 
   export type PostalCodeResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type SecurityCodeResolver = (
     parent: CreditCardInformation,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -3434,77 +3434,77 @@ export namespace CreditCardInformationResolvers {
   export interface Type {
     cardNumber: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     country: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     createdAt: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     expiresOnMonth: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     expiresOnYear: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => number | Promise<number>;
 
     firstName: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     lastName: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     paymentAccount: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => PaymentAccount | null | Promise<PaymentAccount | null>;
 
     postalCode: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     securityCode: (
       parent: CreditCardInformation,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -3524,42 +3524,42 @@ export namespace NotificationResolvers {
 
   export type CreatedAtResolver = (
     parent: Notification,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: Notification,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type LinkResolver = (
     parent: Notification,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type ReadDateResolver = (
     parent: Notification,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type TypeResolver = (
     parent: Notification,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>;
 
   export type UserResolver = (
     parent: Notification,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | Promise<User>;
@@ -3567,42 +3567,42 @@ export namespace NotificationResolvers {
   export interface Type {
     createdAt: (
       parent: Notification,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: Notification,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     link: (
       parent: Notification,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     readDate: (
       parent: Notification,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     type: (
       parent: Notification,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>;
 
     user: (
       parent: Notification,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
@@ -3619,28 +3619,28 @@ export namespace MessageResolvers {
 
   export type CreatedAtResolver = (
     parent: Message,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type DeliveredAtResolver = (
     parent: Message,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type IdResolver = (
     parent: Message,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type ReadAtResolver = (
     parent: Message,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
@@ -3648,28 +3648,28 @@ export namespace MessageResolvers {
   export interface Type {
     createdAt: (
       parent: Message,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     deliveredAt: (
       parent: Message,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     id: (
       parent: Message,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     readAt: (
       parent: Message,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
@@ -3711,28 +3711,28 @@ export namespace MutationResolvers {
   }
 
   export type SignupResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsSignup,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => AuthPayload | Promise<AuthPayload>;
 
   export type LoginResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsLogin,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => AuthPayload | Promise<AuthPayload>;
 
   export type AddPaymentMethodResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsAddPaymentMethod,
     ctx: Context,
     info: GraphQLResolveInfo
   ) => MutationResult | Promise<MutationResult>;
 
   export type BookResolver = (
-    parent: never,
+    parent: undefined,
     args: ArgsBook,
     ctx: Context,
     info: GraphQLResolveInfo
@@ -3740,28 +3740,28 @@ export namespace MutationResolvers {
 
   export interface Type {
     signup: (
-      parent: never,
+      parent: undefined,
       args: ArgsSignup,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => AuthPayload | Promise<AuthPayload>;
 
     login: (
-      parent: never,
+      parent: undefined,
       args: ArgsLogin,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => AuthPayload | Promise<AuthPayload>;
 
     addPaymentMethod: (
-      parent: never,
+      parent: undefined,
       args: ArgsAddPaymentMethod,
       ctx: Context,
       info: GraphQLResolveInfo
     ) => MutationResult | Promise<MutationResult>;
 
     book: (
-      parent: never,
+      parent: undefined,
       args: ArgsBook,
       ctx: Context,
       info: GraphQLResolveInfo
@@ -3777,14 +3777,14 @@ export namespace AuthPayloadResolvers {
 
   export type TokenResolver = (
     parent: AuthPayload,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
   export type UserResolver = (
     parent: AuthPayload,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => User | Promise<User>;
@@ -3792,14 +3792,14 @@ export namespace AuthPayloadResolvers {
   export interface Type {
     token: (
       parent: AuthPayload,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => string | Promise<string>;
 
     user: (
       parent: AuthPayload,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => User | Promise<User>;
@@ -3813,7 +3813,7 @@ export namespace MutationResultResolvers {
 
   export type SuccessResolver = (
     parent: MutationResult,
-    args: never,
+    args: {},
     ctx: Context,
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
@@ -3821,7 +3821,7 @@ export namespace MutationResultResolvers {
   export interface Type {
     success: (
       parent: MutationResult,
-      args: never,
+      args: {},
       ctx: Context,
       info: GraphQLResolveInfo
     ) => boolean | Promise<boolean>;


### PR DESCRIPTION
`never` makes it impossible to pass in an argument when testing resolvers, and since graphql just passes in `undefined` or an empty object (`{}`), we should define the types as such.

This more or less reverts #273