### PR TITLE
chore: fix yarn license warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "license": "MIT",
   "scripts": {
     "build": "cd packages/graphqlgen-json-schema && yarn build && cd ../graphqlgen && yarn build",
     "test": "yarn build && cd packages/graphqlgen && yarn test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "license": "MIT",
   "scripts": {
     "build": "cd packages/graphqlgen-json-schema && yarn build && cd ../graphqlgen && yarn build",
     "test": "yarn build && cd packages/graphqlgen && yarn test"
@@ -12,5 +11,6 @@
     "semi": false,
     "trailingComma": "all",
     "singleQuote": true
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/graphqlgen-json-schema/package.json
+++ b/packages/graphqlgen-json-schema/package.json
@@ -1,6 +1,5 @@
 {
   "name": "graphqlgen-json-schema",
-  "license": "MIT",
   "version": "0.2.12",
   "main": "dist/definition.js",
   "typings": "dist/definition.d.ts",
@@ -24,5 +23,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/prisma/graphqlgen.git"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/graphqlgen-json-schema/package.json
+++ b/packages/graphqlgen-json-schema/package.json
@@ -1,5 +1,6 @@
 {
   "name": "graphqlgen-json-schema",
+  "license": "MIT",
   "version": "0.2.12",
   "main": "dist/definition.js",
   "typings": "dist/definition.d.ts",


### PR DESCRIPTION
e.g.:

```
❯ yarn build
yarn run v1.12.3
$ cd packages/graphqlgen-json-schema && yarn build && cd ../graphqlgen && yarn build
warning package.json: No license field
```