### PR TITLE
Check `modelDef.getType()` is defined before use

### DIFF
--- a/packages/graphqlgen/src/generators/common.ts
+++ b/packages/graphqlgen/src/generators/common.ts
@@ -41,11 +41,10 @@ export function fieldsFromModelDefinition(
   // If model is of type `type TypeName = { ... }`
   if (
     modelDef.kind === 'TypeAliasDefinition' &&
-    (modelDef as TypeAliasDefinition).getType() &&
-    (modelDef as TypeAliasDefinition).getType().kind ===
-      'AnonymousInterfaceAnnotation'
+    modelDef.getType() &&
+    modelDef.getType().kind === 'AnonymousInterfaceAnnotation'
   ) {
-    const interfaceDef = (modelDef as TypeAliasDefinition).getType() as AnonymousInterfaceAnnotation
+    const interfaceDef = modelDef.getType() as AnonymousInterfaceAnnotation
 
     return interfaceDef.fields
   }

--- a/packages/graphqlgen/src/generators/common.ts
+++ b/packages/graphqlgen/src/generators/common.ts
@@ -41,6 +41,7 @@ export function fieldsFromModelDefinition(
   // If model is of type `type TypeName = { ... }`
   if (
     modelDef.kind === 'TypeAliasDefinition' &&
+    (modelDef as TypeAliasDefinition).getType() &&
     (modelDef as TypeAliasDefinition).getType().kind ===
       'AnonymousInterfaceAnnotation'
   ) {


### PR DESCRIPTION
It was crashing otherwise. The type format used was directly an alias:

```ts
import * as Models from 'some-external-module'

type Foo = Models.Foo
```

```
(node:20280) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'kind' of undefined
    at fieldsFromModelDefinition (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/generators/common.js:26:27)
    at Object.renderDefaultResolvers (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/generators/common.js:40:60)
    at renderNamespace (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/generators/ts-generator.js:85:96)
    at /Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/generators/ts-generator.js:80:16
    at Array.map (<anonymous>)
    at renderNamespaces (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/generators/ts-generator.js:79:10)
    at Object.generate (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/generators/ts-generator.js:51:93)
    at generateTypes (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/index.js:84:38)
    at generateCode (/Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/index.js:105:26)
    at /Users/blakeembrey/Projects/GitHub/blakeembrey/authkit-service/functions/admin-graphql/node_modules/graphqlgen/dist/index.js:195:26
```