### PR TITLE
generate interfaces for graphql interfaces

### DIFF
--- a/packages/graphqlgen/src/generators/common.ts
+++ b/packages/graphqlgen/src/generators/common.ts
@@ -19,6 +19,7 @@ import {
   isFieldDefinitionEnumOrLiteral,
   getEnumValues,
 } from '../introspection/utils'
+import { uniq } from '../utils'
 
 type SpecificGraphQLScalarType = 'boolean' | 'number' | 'string'
 
@@ -246,9 +247,9 @@ export const printFieldLikeType = (
   if (field.type.isInterface || field.type.isUnion) {
     const typesMap = field.type.isInterface ? interfacesMap : unionsMap
 
-    const modelNames = typesMap[field.type.name].map(type =>
-      getModelName(type, modelMap),
-    )
+    const modelNames = typesMap[field.type.name]
+      .map(type => getModelName(type, modelMap))
+      .filter(uniq)
 
     let rendering = union(modelNames)
 
@@ -258,10 +259,10 @@ export const printFieldLikeType = (
 
     if (field.type.isArray) {
       rendering = array(rendering, { innerUnion: false })
-    }
 
-    if (!field.type.isArrayRequired) {
-      rendering = nullable(rendering)
+      if (!field.type.isArrayRequired) {
+        rendering = nullable(rendering)
+      }
     }
 
     // We do not have to handle defaults becuase graphql only

--- a/packages/graphqlgen/src/generators/ts-generator.ts
+++ b/packages/graphqlgen/src/generators/ts-generator.ts
@@ -236,6 +236,8 @@ function renderInterfaceNamespace(
         unionsMap,
       )}
 
+      ${renderResolverTypeInterfaceUnion(graphQLTypeObject)}
+
       export interface Type {
         __resolveType: GraphQLTypeResolver<${graphQLTypeObject.implementors
           .map(interfaceType => getModelName(interfaceType, args.modelMap))
@@ -469,6 +471,16 @@ function renderResolverFunctionInterface(
 
   return `
   export type ${resolverName} = ${resolverDefinition} => ${returnType} | Promise<${returnType}>
+  `
+}
+
+function renderResolverTypeInterfaceUnion(
+  type: GraphQLInterfaceObject,
+): string {
+  return `
+  export type InterfaceType = ${type.implementors
+    .map(impl => `${impl.name}Resolvers.Type`)
+    .join(' | ')}
   `
 }
 

--- a/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -517,6 +517,8 @@ export namespace VideoResolvers {
 }
 
 export namespace MediaResolvers {
+  export type InterfaceType = ImageResolvers.Type | VideoResolvers.Type;
+
   export interface Type {
     __resolveType: GraphQLTypeResolver<Image | Video, Context>;
   }


### PR DESCRIPTION
As implemented before in #149, this generates a typescript interface for every graphql interface.

I also made sure the generated field type unions have distinct types.