### PR TITLE
feat(gg): allow delegated-parent-resolvers

### DIFF
--- a/packages/graphqlgen/src/generators/ts-generator.ts
+++ b/packages/graphqlgen/src/generators/ts-generator.ts
@@ -542,11 +542,18 @@ const renderTypeResolver = (
     `
   }
 
-  const func = `
-    ${params} => ${resolverReturnType(returnType)}
+  const func = `${params} => ${resolverReturnType(returnType)}`
+
+  const DelegatedParentResolver = `
+    {
+      fragment: string
+      resolver: ${func}
+    }
   `
 
-  return func
+  const resolver = union([`(${func})`, DelegatedParentResolver])
+
+  return resolver
 }
 
 function renderResolvers(args: GenerateArgs): string {

--- a/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -18,20 +18,40 @@ export namespace QueryResolvers {
     type: EnumAnnotation;
   }
 
-  export type CreateUserResolver = (
-    parent: undefined,
-    args: ArgsCreateUser,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | null | Promise<User | null>;
+  export type CreateUserResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCreateUser,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | null | Promise<User | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCreateUser,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | null | Promise<User | null>;
+      };
 
   export interface Type {
-    createUser: (
-      parent: undefined,
-      args: ArgsCreateUser,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | null | Promise<User | null>;
+    createUser:
+      | ((
+          parent: undefined,
+          args: ArgsCreateUser,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | null | Promise<User | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCreateUser,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | null | Promise<User | null>;
+        };
   }
 }
 
@@ -42,62 +62,142 @@ export namespace UserResolvers {
     enumAsUnionType: (parent: User) => parent.enumAsUnionType
   };
 
-  export type IdResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type NameResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type EnumAnnotationResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => EnumAnnotation | Promise<EnumAnnotation>;
+  export type EnumAnnotationResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => EnumAnnotation | Promise<EnumAnnotation>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => EnumAnnotation | Promise<EnumAnnotation>;
+      };
 
-  export type EnumAsUnionTypeResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => EnumAsUnionType | Promise<EnumAsUnionType>;
+  export type EnumAsUnionTypeResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => EnumAsUnionType | Promise<EnumAsUnionType>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => EnumAsUnionType | Promise<EnumAsUnionType>;
+      };
 
   export interface Type {
-    id: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    name:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    enumAnnotation: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => EnumAnnotation | Promise<EnumAnnotation>;
+    enumAnnotation:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => EnumAnnotation | Promise<EnumAnnotation>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => EnumAnnotation | Promise<EnumAnnotation>;
+        };
 
-    enumAsUnionType: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => EnumAsUnionType | Promise<EnumAsUnionType>;
+    enumAsUnionType:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => EnumAsUnionType | Promise<EnumAsUnionType>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => EnumAsUnionType | Promise<EnumAsUnionType>;
+        };
   }
 }
 
@@ -204,34 +304,74 @@ export namespace MutationResolvers {
     data: AddMemberData[];
   }
 
-  export type AddMemberResolver = (
-    parent: undefined,
-    args: ArgsAddMember,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => AddMemberPayload | Promise<AddMemberPayload>;
+  export type AddMemberResolver =
+    | ((
+        parent: undefined,
+        args: ArgsAddMember,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => AddMemberPayload | Promise<AddMemberPayload>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsAddMember,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AddMemberPayload | Promise<AddMemberPayload>;
+      };
 
-  export type AddMembersResolver = (
-    parent: undefined,
-    args: ArgsAddMembers,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => AddMemberPayload | Promise<AddMemberPayload>;
+  export type AddMembersResolver =
+    | ((
+        parent: undefined,
+        args: ArgsAddMembers,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => AddMemberPayload | Promise<AddMemberPayload>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsAddMembers,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AddMemberPayload | Promise<AddMemberPayload>;
+      };
 
   export interface Type {
-    addMember: (
-      parent: undefined,
-      args: ArgsAddMember,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => AddMemberPayload | Promise<AddMemberPayload>;
+    addMember:
+      | ((
+          parent: undefined,
+          args: ArgsAddMember,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AddMemberPayload | Promise<AddMemberPayload>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsAddMember,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => AddMemberPayload | Promise<AddMemberPayload>;
+        };
 
-    addMembers: (
-      parent: undefined,
-      args: ArgsAddMembers,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => AddMemberPayload | Promise<AddMemberPayload>;
+    addMembers:
+      | ((
+          parent: undefined,
+          args: ArgsAddMembers,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AddMemberPayload | Promise<AddMemberPayload>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsAddMembers,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => AddMemberPayload | Promise<AddMemberPayload>;
+        };
   }
 }
 
@@ -240,34 +380,74 @@ export namespace AddMemberPayloadResolvers {
     newUserId: (parent: AddMemberPayload) => parent.newUserId
   };
 
-  export type NewUserIdResolver = (
-    parent: AddMemberPayload,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type NewUserIdResolver =
+    | ((
+        parent: AddMemberPayload,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: AddMemberPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type ExistingUserInviteSentResolver = (
-    parent: AddMemberPayload,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type ExistingUserInviteSentResolver =
+    | ((
+        parent: AddMemberPayload,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: AddMemberPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
   export interface Type {
-    newUserId: (
-      parent: AddMemberPayload,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    newUserId:
+      | ((
+          parent: AddMemberPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: AddMemberPayload,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    existingUserInviteSent: (
-      parent: AddMemberPayload,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    existingUserInviteSent:
+      | ((
+          parent: AddMemberPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: AddMemberPayload,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
   }
 }
 
@@ -354,40 +534,86 @@ export namespace QueryResolvers {
     id: number;
   }
 
-  export type MediaResolver = (
-    parent: undefined,
-    args: ArgsMedia,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) =>
-    | Array<Image | Video | null>
-    | null
-    | Promise<Array<Image | Video | null> | null>;
+  export type MediaResolver =
+    | ((
+        parent: undefined,
+        args: ArgsMedia,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) =>
+        | Array<Image | Video | null>
+        | null
+        | Promise<Array<Image | Video | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsMedia,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<Image | Video | null>
+          | null
+          | Promise<Array<Image | Video | null> | null>;
+      };
 
-  export type MediaItemResolver = (
-    parent: undefined,
-    args: ArgsMediaItem,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Image | Video | null | Promise<Image | Video | null>;
+  export type MediaItemResolver =
+    | ((
+        parent: undefined,
+        args: ArgsMediaItem,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Image | Video | null | Promise<Image | Video | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsMediaItem,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Image | Video | null | Promise<Image | Video | null>;
+      };
 
   export interface Type {
-    media: (
-      parent: undefined,
-      args: ArgsMedia,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) =>
-      | Array<Image | Video | null>
-      | null
-      | Promise<Array<Image | Video | null> | null>;
+    media:
+      | ((
+          parent: undefined,
+          args: ArgsMedia,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<Image | Video | null>
+          | null
+          | Promise<Array<Image | Video | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsMedia,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<Image | Video | null>
+            | null
+            | Promise<Array<Image | Video | null> | null>;
+        };
 
-    mediaItem: (
-      parent: undefined,
-      args: ArgsMediaItem,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Image | Video | null | Promise<Image | Video | null>;
+    mediaItem:
+      | ((
+          parent: undefined,
+          args: ArgsMediaItem,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Image | Video | null | Promise<Image | Video | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsMediaItem,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Image | Video | null | Promise<Image | Video | null>;
+        };
   }
 }
 
@@ -397,34 +623,74 @@ export namespace DimensionsResolvers {
     height: (parent: Dimensions) => parent.height
   };
 
-  export type WidthResolver = (
-    parent: Dimensions,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type WidthResolver =
+    | ((
+        parent: Dimensions,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Dimensions,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type HeightResolver = (
-    parent: Dimensions,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type HeightResolver =
+    | ((
+        parent: Dimensions,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Dimensions,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    width: (
-      parent: Dimensions,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    width:
+      | ((
+          parent: Dimensions,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Dimensions,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    height: (
-      parent: Dimensions,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    height:
+      | ((
+          parent: Dimensions,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Dimensions,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -433,48 +699,108 @@ export namespace ImageResolvers {
     dimensions: (parent: Image) => parent.dimensions
   };
 
-  export type IdResolver = (
-    parent: Image,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Image,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Image,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type UrlResolver = (
-    parent: Image,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type UrlResolver =
+    | ((
+        parent: Image,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Image,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type DimensionsResolver = (
-    parent: Image,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Dimensions | Promise<Dimensions>;
+  export type DimensionsResolver =
+    | ((
+        parent: Image,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Dimensions | Promise<Dimensions>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Image,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Dimensions | Promise<Dimensions>;
+      };
 
   export interface Type {
-    id: (
-      parent: Image,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Image,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Image,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    url: (
-      parent: Image,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    url:
+      | ((
+          parent: Image,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Image,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    dimensions: (
-      parent: Image,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Dimensions | Promise<Dimensions>;
+    dimensions:
+      | ((
+          parent: Image,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Dimensions | Promise<Dimensions>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Image,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Dimensions | Promise<Dimensions>;
+        };
 
     __isTypeOf?: GraphQLIsTypeOfFn<Image | Video, Context>;
   }
@@ -483,48 +809,108 @@ export namespace ImageResolvers {
 export namespace VideoResolvers {
   export const defaultResolvers = {};
 
-  export type IdResolver = (
-    parent: Video,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Video,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Video,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type UrlResolver = (
-    parent: Video,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type UrlResolver =
+    | ((
+        parent: Video,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Video,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type DurationResolver = (
-    parent: Video,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type DurationResolver =
+    | ((
+        parent: Video,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Video,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: Video,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Video,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Video,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    url: (
-      parent: Video,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    url:
+      | ((
+          parent: Video,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Video,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    duration: (
-      parent: Video,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    duration:
+      | ((
+          parent: Video,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Video,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
     __isTypeOf?: GraphQLIsTypeOfFn<Image | Video, Context>;
   }
@@ -685,20 +1071,40 @@ export namespace MutationResolvers {
     data: AddMemberData;
   }
 
-  export type AddMemberResolver = (
-    parent: undefined,
-    args: ArgsAddMember,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => AddMemberPayload | Promise<AddMemberPayload>;
+  export type AddMemberResolver =
+    | ((
+        parent: undefined,
+        args: ArgsAddMember,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => AddMemberPayload | Promise<AddMemberPayload>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsAddMember,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AddMemberPayload | Promise<AddMemberPayload>;
+      };
 
   export interface Type {
-    addMember: (
-      parent: undefined,
-      args: ArgsAddMember,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => AddMemberPayload | Promise<AddMemberPayload>;
+    addMember:
+      | ((
+          parent: undefined,
+          args: ArgsAddMember,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AddMemberPayload | Promise<AddMemberPayload>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsAddMember,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => AddMemberPayload | Promise<AddMemberPayload>;
+        };
   }
 }
 
@@ -707,20 +1113,40 @@ export namespace AddMemberPayloadResolvers {
     json: (parent: AddMemberPayload) => parent.json
   };
 
-  export type JsonResolver = (
-    parent: AddMemberPayload,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type JsonResolver =
+    | ((
+        parent: AddMemberPayload,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: AddMemberPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
   export interface Type {
-    json: (
-      parent: AddMemberPayload,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    json:
+      | ((
+          parent: AddMemberPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: AddMemberPayload,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
   }
 }
 
@@ -808,188 +1234,460 @@ export namespace QueryResolvers {
     id: Number;
   }
 
-  export type IdResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type Custom_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | Promise<Number>;
+  export type Custom_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | Promise<Number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>;
+      };
 
-  export type Custom_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | null | Promise<Number | null>;
+  export type Custom_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | null | Promise<Number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | null | Promise<Number | null>;
+      };
 
-  export type Custom_array_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+  export type Custom_array_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+      };
 
-  export type Custom_array_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<Number | null> | Promise<Array<Number | null>>;
+  export type Custom_array_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<Number | null> | Promise<Array<Number | null>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | Promise<Array<Number | null>>;
+      };
 
-  export type Custom_with_argResolver = (
-    parent: undefined,
-    args: ArgsCustom_with_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | Promise<Number>;
+  export type Custom_with_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCustom_with_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | Promise<Number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCustom_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>;
+      };
 
-  export type Custom_with_custom_argResolver = (
-    parent: undefined,
-    args: ArgsCustom_with_custom_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | Promise<Number>;
+  export type Custom_with_custom_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCustom_with_custom_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | Promise<Number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCustom_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>;
+      };
 
-  export type Scalar_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type Scalar_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type Scalar_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type Scalar_array_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+  export type Scalar_array_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<boolean | null>
+          | null
+          | Promise<Array<boolean | null> | null>;
+      };
 
-  export type Scalar_array_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+  export type Scalar_array_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+      };
 
-  export type Scalar_with_argResolver = (
-    parent: undefined,
-    args: ArgsScalar_with_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_with_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsScalar_with_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsScalar_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type Scalar_with_custom_argResolver = (
-    parent: undefined,
-    args: ArgsScalar_with_custom_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_with_custom_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsScalar_with_custom_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsScalar_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
   export interface Type {
-    id: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    custom_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | Promise<Number>;
+    custom_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | Promise<Number>;
+        };
 
-    custom_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | null | Promise<Number | null>;
+    custom_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | null | Promise<Number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | null | Promise<Number | null>;
+        };
 
-    custom_array_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+    custom_array_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<Number | null>
+            | null
+            | Promise<Array<Number | null> | null>;
+        };
 
-    custom_array_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<Number | null> | Promise<Array<Number | null>>;
+    custom_array_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | Promise<Array<Number | null>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<Number | null> | Promise<Array<Number | null>>;
+        };
 
-    custom_with_arg: (
-      parent: undefined,
-      args: ArgsCustom_with_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | Promise<Number>;
+    custom_with_arg:
+      | ((
+          parent: undefined,
+          args: ArgsCustom_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCustom_with_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | Promise<Number>;
+        };
 
-    custom_with_custom_arg: (
-      parent: undefined,
-      args: ArgsCustom_with_custom_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | Promise<Number>;
+    custom_with_custom_arg:
+      | ((
+          parent: undefined,
+          args: ArgsCustom_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCustom_with_custom_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | Promise<Number>;
+        };
 
-    scalar_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    scalar_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    scalar_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    scalar_array_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+    scalar_array_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<boolean | null>
+          | null
+          | Promise<Array<boolean | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<boolean | null>
+            | null
+            | Promise<Array<boolean | null> | null>;
+        };
 
-    scalar_array_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+    scalar_array_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+        };
 
-    scalar_with_arg: (
-      parent: undefined,
-      args: ArgsScalar_with_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_with_arg:
+      | ((
+          parent: undefined,
+          args: ArgsScalar_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsScalar_with_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    scalar_with_custom_arg: (
-      parent: undefined,
-      args: ArgsScalar_with_custom_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_with_custom_arg:
+      | ((
+          parent: undefined,
+          args: ArgsScalar_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsScalar_with_custom_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
   }
 }
 
@@ -999,34 +1697,74 @@ export namespace NumberResolvers {
     value: (parent: Number) => parent.value
   };
 
-  export type IdResolver = (
-    parent: Number,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type IdResolver =
+    | ((
+        parent: Number,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type ValueResolver = (
-    parent: Number,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type ValueResolver =
+    | ((
+        parent: Number,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
   export interface Type {
-    id: (
-      parent: Number,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    id:
+      | ((
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Number,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    value: (
-      parent: Number,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    value:
+      | ((
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Number,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
   }
 }
 
@@ -1138,20 +1876,40 @@ export namespace QueryResolvers {
     first?: number | null;
   }
 
-  export type UsersResolver = (
-    parent: undefined,
-    args: ArgsUsers,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+  export type UsersResolver =
+    | ((
+        parent: undefined,
+        args: ArgsUsers,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<Student | Professor> | Promise<Array<Student | Professor>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsUsers,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+      };
 
   export interface Type {
-    users: (
-      parent: undefined,
-      args: ArgsUsers,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+    users:
+      | ((
+          parent: undefined,
+          args: ArgsUsers,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Student | Professor> | Promise<Array<Student | Professor>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsUsers,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+        };
   }
 }
 
@@ -1160,20 +1918,40 @@ export namespace StudentResolvers {
     age: (parent: Student) => parent.age
   };
 
-  export type AgeResolver = (
-    parent: Student,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type AgeResolver =
+    | ((
+        parent: Student,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Student,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    age: (
-      parent: Student,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    age:
+      | ((
+          parent: Student,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Student,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
     __isTypeOf?: GraphQLIsTypeOfFn<Student | Professor, Context>;
   }
@@ -1184,20 +1962,40 @@ export namespace ProfessorResolvers {
     degree: (parent: Professor) => parent.degree
   };
 
-  export type DegreeResolver = (
-    parent: Professor,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type DegreeResolver =
+    | ((
+        parent: Professor,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Professor,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
   export interface Type {
-    degree: (
-      parent: Professor,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    degree:
+      | ((
+          parent: Professor,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Professor,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
     __isTypeOf?: GraphQLIsTypeOfFn<Student | Professor, Context>;
   }
@@ -1209,34 +2007,74 @@ export namespace UserResolvers {
     name: (parent: User) => parent.name
   };
 
-  export type IdResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type NameResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    id: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    name:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -1365,20 +2203,40 @@ import { User, Context } from \\"../../fixtures/context/types\\";
 export namespace QueryResolvers {
   export const defaultResolvers = {};
 
-  export type CreateUserResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | null | Promise<User | null>;
+  export type CreateUserResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | null | Promise<User | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | null | Promise<User | null>;
+      };
 
   export interface Type {
-    createUser: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | null | Promise<User | null>;
+    createUser:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | null | Promise<User | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | null | Promise<User | null>;
+        };
   }
 }
 
@@ -1387,20 +2245,40 @@ export namespace UserResolvers {
     id: (parent: User) => parent.id
   };
 
-  export type IdResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    id: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -1488,194 +2366,469 @@ export namespace QueryResolvers {
     id: NumberNode;
   }
 
-  export type IdResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type Custom_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => NumberNode | Promise<NumberNode>;
+  export type Custom_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => NumberNode | Promise<NumberNode>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | Promise<NumberNode>;
+      };
 
-  export type Custom_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => NumberNode | null | Promise<NumberNode | null>;
+  export type Custom_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => NumberNode | null | Promise<NumberNode | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | null | Promise<NumberNode | null>;
+      };
 
-  export type Custom_array_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) =>
-    | Array<NumberNode | null>
-    | null
-    | Promise<Array<NumberNode | null> | null>;
+  export type Custom_array_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) =>
+        | Array<NumberNode | null>
+        | null
+        | Promise<Array<NumberNode | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<NumberNode | null>
+          | null
+          | Promise<Array<NumberNode | null> | null>;
+      };
 
-  export type Custom_array_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+  export type Custom_array_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+      };
 
-  export type Custom_with_argResolver = (
-    parent: undefined,
-    args: ArgsCustom_with_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => NumberNode | Promise<NumberNode>;
+  export type Custom_with_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCustom_with_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => NumberNode | Promise<NumberNode>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCustom_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | Promise<NumberNode>;
+      };
 
-  export type Custom_with_custom_argResolver = (
-    parent: undefined,
-    args: ArgsCustom_with_custom_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => NumberNode | Promise<NumberNode>;
+  export type Custom_with_custom_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCustom_with_custom_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => NumberNode | Promise<NumberNode>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCustom_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | Promise<NumberNode>;
+      };
 
-  export type Scalar_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type Scalar_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type Scalar_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type Scalar_array_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+  export type Scalar_array_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<boolean | null>
+          | null
+          | Promise<Array<boolean | null> | null>;
+      };
 
-  export type Scalar_array_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+  export type Scalar_array_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+      };
 
-  export type Scalar_with_argResolver = (
-    parent: undefined,
-    args: ArgsScalar_with_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_with_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsScalar_with_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsScalar_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type Scalar_with_custom_argResolver = (
-    parent: undefined,
-    args: ArgsScalar_with_custom_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_with_custom_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsScalar_with_custom_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsScalar_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
   export interface Type {
-    id: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    custom_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => NumberNode | Promise<NumberNode>;
+    custom_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | Promise<NumberNode>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => NumberNode | Promise<NumberNode>;
+        };
 
-    custom_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => NumberNode | null | Promise<NumberNode | null>;
+    custom_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | null | Promise<NumberNode | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => NumberNode | null | Promise<NumberNode | null>;
+        };
 
-    custom_array_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) =>
-      | Array<NumberNode | null>
-      | null
-      | Promise<Array<NumberNode | null> | null>;
+    custom_array_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<NumberNode | null>
+          | null
+          | Promise<Array<NumberNode | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<NumberNode | null>
+            | null
+            | Promise<Array<NumberNode | null> | null>;
+        };
 
-    custom_array_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+    custom_array_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+        };
 
-    custom_with_arg: (
-      parent: undefined,
-      args: ArgsCustom_with_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => NumberNode | Promise<NumberNode>;
+    custom_with_arg:
+      | ((
+          parent: undefined,
+          args: ArgsCustom_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | Promise<NumberNode>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCustom_with_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => NumberNode | Promise<NumberNode>;
+        };
 
-    custom_with_custom_arg: (
-      parent: undefined,
-      args: ArgsCustom_with_custom_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => NumberNode | Promise<NumberNode>;
+    custom_with_custom_arg:
+      | ((
+          parent: undefined,
+          args: ArgsCustom_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NumberNode | Promise<NumberNode>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCustom_with_custom_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => NumberNode | Promise<NumberNode>;
+        };
 
-    scalar_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    scalar_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    scalar_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    scalar_array_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+    scalar_array_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<boolean | null>
+          | null
+          | Promise<Array<boolean | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<boolean | null>
+            | null
+            | Promise<Array<boolean | null> | null>;
+        };
 
-    scalar_array_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+    scalar_array_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+        };
 
-    scalar_with_arg: (
-      parent: undefined,
-      args: ArgsScalar_with_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_with_arg:
+      | ((
+          parent: undefined,
+          args: ArgsScalar_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsScalar_with_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    scalar_with_custom_arg: (
-      parent: undefined,
-      args: ArgsScalar_with_custom_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_with_custom_arg:
+      | ((
+          parent: undefined,
+          args: ArgsScalar_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsScalar_with_custom_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
   }
 }
 
@@ -1685,34 +2838,74 @@ export namespace NumberResolvers {
     value: (parent: NumberNode) => parent.value
   };
 
-  export type IdResolver = (
-    parent: NumberNode,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type IdResolver =
+    | ((
+        parent: NumberNode,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: NumberNode,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type ValueResolver = (
-    parent: NumberNode,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type ValueResolver =
+    | ((
+        parent: NumberNode,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: NumberNode,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
   export interface Type {
-    id: (
-      parent: NumberNode,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    id:
+      | ((
+          parent: NumberNode,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: NumberNode,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    value: (
-      parent: NumberNode,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    value:
+      | ((
+          parent: NumberNode,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: NumberNode,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
   }
 }
 
@@ -1836,188 +3029,460 @@ export namespace QueryResolvers {
     id: Number;
   }
 
-  export type IdResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type Custom_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | Promise<Number>;
+  export type Custom_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | Promise<Number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>;
+      };
 
-  export type Custom_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | null | Promise<Number | null>;
+  export type Custom_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | null | Promise<Number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | null | Promise<Number | null>;
+      };
 
-  export type Custom_array_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+  export type Custom_array_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+      };
 
-  export type Custom_array_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<Number | null> | Promise<Array<Number | null>>;
+  export type Custom_array_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<Number | null> | Promise<Array<Number | null>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | Promise<Array<Number | null>>;
+      };
 
-  export type Custom_with_argResolver = (
-    parent: undefined,
-    args: ArgsCustom_with_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | Promise<Number>;
+  export type Custom_with_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCustom_with_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | Promise<Number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCustom_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>;
+      };
 
-  export type Custom_with_custom_argResolver = (
-    parent: undefined,
-    args: ArgsCustom_with_custom_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Number | Promise<Number>;
+  export type Custom_with_custom_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsCustom_with_custom_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Number | Promise<Number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsCustom_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>;
+      };
 
-  export type Scalar_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type Scalar_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type Scalar_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type Scalar_array_nullableResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+  export type Scalar_array_nullableResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<boolean | null>
+          | null
+          | Promise<Array<boolean | null> | null>;
+      };
 
-  export type Scalar_array_requiredResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+  export type Scalar_array_requiredResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+      };
 
-  export type Scalar_with_argResolver = (
-    parent: undefined,
-    args: ArgsScalar_with_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_with_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsScalar_with_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsScalar_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type Scalar_with_custom_argResolver = (
-    parent: undefined,
-    args: ArgsScalar_with_custom_arg,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type Scalar_with_custom_argResolver =
+    | ((
+        parent: undefined,
+        args: ArgsScalar_with_custom_arg,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsScalar_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
   export interface Type {
-    id: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    custom_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | Promise<Number>;
+    custom_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | Promise<Number>;
+        };
 
-    custom_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | null | Promise<Number | null>;
+    custom_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | null | Promise<Number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | null | Promise<Number | null>;
+        };
 
-    custom_array_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+    custom_array_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<Number | null>
+            | null
+            | Promise<Array<Number | null> | null>;
+        };
 
-    custom_array_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<Number | null> | Promise<Array<Number | null>>;
+    custom_array_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<Number | null> | Promise<Array<Number | null>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<Number | null> | Promise<Array<Number | null>>;
+        };
 
-    custom_with_arg: (
-      parent: undefined,
-      args: ArgsCustom_with_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | Promise<Number>;
+    custom_with_arg:
+      | ((
+          parent: undefined,
+          args: ArgsCustom_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCustom_with_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | Promise<Number>;
+        };
 
-    custom_with_custom_arg: (
-      parent: undefined,
-      args: ArgsCustom_with_custom_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Number | Promise<Number>;
+    custom_with_custom_arg:
+      | ((
+          parent: undefined,
+          args: ArgsCustom_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Number | Promise<Number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsCustom_with_custom_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Number | Promise<Number>;
+        };
 
-    scalar_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    scalar_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    scalar_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    scalar_array_nullable: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+    scalar_array_nullable:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | Array<boolean | null>
+          | null
+          | Promise<Array<boolean | null> | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | Array<boolean | null>
+            | null
+            | Promise<Array<boolean | null> | null>;
+        };
 
-    scalar_array_required: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+    scalar_array_required:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+        };
 
-    scalar_with_arg: (
-      parent: undefined,
-      args: ArgsScalar_with_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_with_arg:
+      | ((
+          parent: undefined,
+          args: ArgsScalar_with_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsScalar_with_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    scalar_with_custom_arg: (
-      parent: undefined,
-      args: ArgsScalar_with_custom_arg,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    scalar_with_custom_arg:
+      | ((
+          parent: undefined,
+          args: ArgsScalar_with_custom_arg,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsScalar_with_custom_arg,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
   }
 }
 
@@ -2027,34 +3492,74 @@ export namespace NumberResolvers {
     value: (parent: Number) => parent.value
   };
 
-  export type IdResolver = (
-    parent: Number,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type IdResolver =
+    | ((
+        parent: Number,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type ValueResolver = (
-    parent: Number,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type ValueResolver =
+    | ((
+        parent: Number,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
   export interface Type {
-    id: (
-      parent: Number,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    id:
+      | ((
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Number,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    value: (
-      parent: Number,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    value:
+      | ((
+          parent: Number,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Number,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
   }
 }
 
@@ -2200,20 +3705,40 @@ export namespace UserResolvers {
     name: (parent: User) => parent.name
   };
 
-  export type NameResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type NameResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    name: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    name:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 

--- a/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -543,7 +543,8 @@ export namespace QueryResolvers {
       ) =>
         | Array<Image | Video | null>
         | null
-        | Promise<Array<Image | Video | null> | null>)
+        | Promise<Array<Image | Video | null> | null>
+      )
     | {
         fragment: string;
         resolver: (
@@ -584,7 +585,8 @@ export namespace QueryResolvers {
         ) =>
           | Array<Image | Video | null>
           | null
-          | Promise<Array<Image | Video | null> | null>)
+          | Promise<Array<Image | Video | null> | null>
+        )
       | {
           fragment: string;
           resolver: (
@@ -1624,7 +1626,8 @@ export namespace QueryResolvers {
         ) =>
           | Array<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>)
+          | Promise<Array<boolean | null> | null>
+        )
       | {
           fragment: string;
           resolver: (
@@ -2426,7 +2429,8 @@ export namespace QueryResolvers {
       ) =>
         | Array<NumberNode | null>
         | null
-        | Promise<Array<NumberNode | null> | null>)
+        | Promise<Array<NumberNode | null> | null>
+      )
     | {
         fragment: string;
         resolver: (
@@ -2657,7 +2661,8 @@ export namespace QueryResolvers {
         ) =>
           | Array<NumberNode | null>
           | null
-          | Promise<Array<NumberNode | null> | null>)
+          | Promise<Array<NumberNode | null> | null>
+        )
       | {
           fragment: string;
           resolver: (
@@ -2765,7 +2770,8 @@ export namespace QueryResolvers {
         ) =>
           | Array<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>)
+          | Promise<Array<boolean | null> | null>
+        )
       | {
           fragment: string;
           resolver: (
@@ -3419,7 +3425,8 @@ export namespace QueryResolvers {
         ) =>
           | Array<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>)
+          | Promise<Array<boolean | null> | null>
+        )
       | {
           fragment: string;
           resolver: (

--- a/packages/graphqlgen/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -7284,7 +7284,8 @@ export namespace PaymentAccountResolvers {
         ) =>
           | CreditCardInformation
           | null
-          | Promise<CreditCardInformation | null>)
+          | Promise<CreditCardInformation | null>
+        )
       | {
           fragment: string;
           resolver: (

--- a/packages/graphqlgen/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -66,118 +66,278 @@ export namespace QueryResolvers {
     cities: string[];
   }
 
-  export type TopExperiencesResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Experience[] | Promise<Experience[]>;
+  export type TopExperiencesResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Experience[] | Promise<Experience[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience[] | Promise<Experience[]>;
+      };
 
-  export type TopHomesResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Home[] | Promise<Home[]>;
+  export type TopHomesResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Home[] | Promise<Home[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Home[] | Promise<Home[]>;
+      };
 
-  export type HomesInPriceRangeResolver = (
-    parent: undefined,
-    args: ArgsHomesInPriceRange,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Home[] | Promise<Home[]>;
+  export type HomesInPriceRangeResolver =
+    | ((
+        parent: undefined,
+        args: ArgsHomesInPriceRange,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Home[] | Promise<Home[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsHomesInPriceRange,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Home[] | Promise<Home[]>;
+      };
 
-  export type TopReservationsResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Reservation[] | Promise<Reservation[]>;
+  export type TopReservationsResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Reservation[] | Promise<Reservation[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Reservation[] | Promise<Reservation[]>;
+      };
 
-  export type FeaturedDestinationsResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+  export type FeaturedDestinationsResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Neighbourhood[] | Promise<Neighbourhood[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+      };
 
-  export type ExperiencesByCityResolver = (
-    parent: undefined,
-    args: ArgsExperiencesByCity,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+  export type ExperiencesByCityResolver =
+    | ((
+        parent: undefined,
+        args: ArgsExperiencesByCity,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsExperiencesByCity,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+      };
 
-  export type ViewerResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Viewer | null | Promise<Viewer | null>;
+  export type ViewerResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Viewer | null | Promise<Viewer | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Viewer | null | Promise<Viewer | null>;
+      };
 
-  export type MyLocationResolver = (
-    parent: undefined,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Location | null | Promise<Location | null>;
+  export type MyLocationResolver =
+    | ((
+        parent: undefined,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Location | null | Promise<Location | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | null | Promise<Location | null>;
+      };
 
   export interface Type {
-    topExperiences: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Experience[] | Promise<Experience[]>;
+    topExperiences:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience[] | Promise<Experience[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Experience[] | Promise<Experience[]>;
+        };
 
-    topHomes: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Home[] | Promise<Home[]>;
+    topHomes:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Home[] | Promise<Home[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Home[] | Promise<Home[]>;
+        };
 
-    homesInPriceRange: (
-      parent: undefined,
-      args: ArgsHomesInPriceRange,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Home[] | Promise<Home[]>;
+    homesInPriceRange:
+      | ((
+          parent: undefined,
+          args: ArgsHomesInPriceRange,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Home[] | Promise<Home[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsHomesInPriceRange,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Home[] | Promise<Home[]>;
+        };
 
-    topReservations: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Reservation[] | Promise<Reservation[]>;
+    topReservations:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Reservation[] | Promise<Reservation[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Reservation[] | Promise<Reservation[]>;
+        };
 
-    featuredDestinations: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+    featuredDestinations:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Neighbourhood[] | Promise<Neighbourhood[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+        };
 
-    experiencesByCity: (
-      parent: undefined,
-      args: ArgsExperiencesByCity,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+    experiencesByCity:
+      | ((
+          parent: undefined,
+          args: ArgsExperiencesByCity,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsExperiencesByCity,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+        };
 
-    viewer: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Viewer | null | Promise<Viewer | null>;
+    viewer:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Viewer | null | Promise<Viewer | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Viewer | null | Promise<Viewer | null>;
+        };
 
-    myLocation: (
-      parent: undefined,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Location | null | Promise<Location | null>;
+    myLocation:
+      | ((
+          parent: undefined,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | null | Promise<Location | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Location | null | Promise<Location | null>;
+        };
   }
 }
 
@@ -194,118 +354,278 @@ export namespace ExperienceResolvers {
     popularity: (parent: Experience) => parent.popularity
   };
 
-  export type IdResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type CategoryResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => ExperienceCategory | null | Promise<ExperienceCategory | null>;
+  export type CategoryResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => ExperienceCategory | null | Promise<ExperienceCategory | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => ExperienceCategory | null | Promise<ExperienceCategory | null>;
+      };
 
-  export type TitleResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type TitleResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LocationResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Location | Promise<Location>;
+  export type LocationResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Location | Promise<Location>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>;
+      };
 
-  export type PricePerPersonResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PricePerPersonResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type ReviewsResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Review[] | Promise<Review[]>;
+  export type ReviewsResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Review[] | Promise<Review[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Review[] | Promise<Review[]>;
+      };
 
-  export type PreviewResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Picture | Promise<Picture>;
+  export type PreviewResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Picture | Promise<Picture>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture | Promise<Picture>;
+      };
 
-  export type PopularityResolver = (
-    parent: Experience,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PopularityResolver =
+    | ((
+        parent: Experience,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    category: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => ExperienceCategory | null | Promise<ExperienceCategory | null>;
+    category:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => ExperienceCategory | null | Promise<ExperienceCategory | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => ExperienceCategory | null | Promise<ExperienceCategory | null>;
+        };
 
-    title: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    title:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    location: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Location | Promise<Location>;
+    location:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Location | Promise<Location>;
+        };
 
-    pricePerPerson: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    pricePerPerson:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    reviews: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Review[] | Promise<Review[]>;
+    reviews:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Review[] | Promise<Review[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Review[] | Promise<Review[]>;
+        };
 
-    preview: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Picture | Promise<Picture>;
+    preview:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture | Promise<Picture>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Picture | Promise<Picture>;
+        };
 
-    popularity: (
-      parent: Experience,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    popularity:
+      | ((
+          parent: Experience,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Experience,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -318,62 +638,142 @@ export namespace ExperienceCategoryResolvers {
       parent.experience === undefined ? null : parent.experience
   };
 
-  export type IdResolver = (
-    parent: ExperienceCategory,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: ExperienceCategory,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type MainColorResolver = (
-    parent: ExperienceCategory,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type MainColorResolver =
+    | ((
+        parent: ExperienceCategory,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: ExperienceCategory,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type NameResolver =
+    | ((
+        parent: ExperienceCategory,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type ExperienceResolver = (
-    parent: ExperienceCategory,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Experience | null | Promise<Experience | null>;
+  export type ExperienceResolver =
+    | ((
+        parent: ExperienceCategory,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Experience | null | Promise<Experience | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience | null | Promise<Experience | null>;
+      };
 
   export interface Type {
-    id: (
-      parent: ExperienceCategory,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: ExperienceCategory,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    mainColor: (
-      parent: ExperienceCategory,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    mainColor:
+      | ((
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: ExperienceCategory,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: ExperienceCategory,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    name:
+      | ((
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: ExperienceCategory,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    experience: (
-      parent: ExperienceCategory,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Experience | null | Promise<Experience | null>;
+    experience:
+      | ((
+          parent: ExperienceCategory,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience | null | Promise<Experience | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: ExperienceCategory,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Experience | null | Promise<Experience | null>;
+        };
   }
 }
 
@@ -388,76 +788,176 @@ export namespace LocationResolvers {
       parent.directions === undefined ? null : parent.directions
   };
 
-  export type IdResolver = (
-    parent: Location,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Location,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LatResolver = (
-    parent: Location,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type LatResolver =
+    | ((
+        parent: Location,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type LngResolver = (
-    parent: Location,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type LngResolver =
+    | ((
+        parent: Location,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type AddressResolver = (
-    parent: Location,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type AddressResolver =
+    | ((
+        parent: Location,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type DirectionsResolver = (
-    parent: Location,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type DirectionsResolver =
+    | ((
+        parent: Location,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
   export interface Type {
-    id: (
-      parent: Location,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Location,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    lat: (
-      parent: Location,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    lat:
+      | ((
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Location,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    lng: (
-      parent: Location,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    lng:
+      | ((
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Location,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    address: (
-      parent: Location,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    address:
+      | ((
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Location,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    directions: (
-      parent: Location,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    directions:
+      | ((
+          parent: Location,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Location,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
   }
 }
 
@@ -475,146 +975,346 @@ export namespace ReviewResolvers {
     value: (parent: Review) => parent.value
   };
 
-  export type AccuracyResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type AccuracyResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CheckInResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type CheckInResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CleanlinessResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type CleanlinessResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CommunicationResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type CommunicationResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LocationResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type LocationResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type StarsResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type StarsResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type TextResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type TextResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type ValueResolver = (
-    parent: Review,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type ValueResolver =
+    | ((
+        parent: Review,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    accuracy: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    accuracy:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    checkIn: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    checkIn:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    cleanliness: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    cleanliness:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    communication: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    communication:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    createdAt: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    location: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    location:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    stars: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    stars:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    text: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    text:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    value: (
-      parent: Review,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    value:
+      | ((
+          parent: Review,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Review,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -624,34 +1324,74 @@ export namespace PictureResolvers {
     url: (parent: Picture) => parent.url
   };
 
-  export type IdResolver = (
-    parent: Picture,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Picture,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Picture,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type UrlResolver = (
-    parent: Picture,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type UrlResolver =
+    | ((
+        parent: Picture,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Picture,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    id: (
-      parent: Picture,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Picture,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Picture,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    url: (
-      parent: Picture,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    url:
+      | ((
+          parent: Picture,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Picture,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -671,104 +1411,244 @@ export namespace HomeResolvers {
     first?: number | null;
   }
 
-  export type IdResolver = (
-    parent: Home,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Home,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: Home,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type NameResolver =
+    | ((
+        parent: Home,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type DescriptionResolver = (
-    parent: Home,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type DescriptionResolver =
+    | ((
+        parent: Home,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NumRatingsResolver = (
-    parent: Home,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type NumRatingsResolver =
+    | ((
+        parent: Home,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type AvgRatingResolver = (
-    parent: Home,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type AvgRatingResolver =
+    | ((
+        parent: Home,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type PicturesResolver = (
-    parent: Home,
-    args: ArgsPictures,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Picture[] | Promise<Picture[]>;
+  export type PicturesResolver =
+    | ((
+        parent: Home,
+        args: ArgsPictures,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Picture[] | Promise<Picture[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: ArgsPictures,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture[] | Promise<Picture[]>;
+      };
 
-  export type PerNightResolver = (
-    parent: Home,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PerNightResolver =
+    | ((
+        parent: Home,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: Home,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: Home,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    name:
+      | ((
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    description: (
-      parent: Home,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    description:
+      | ((
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    numRatings: (
-      parent: Home,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    numRatings:
+      | ((
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    avgRating: (
-      parent: Home,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    avgRating:
+      | ((
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    pictures: (
-      parent: Home,
-      args: ArgsPictures,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Picture[] | Promise<Picture[]>;
+    pictures:
+      | ((
+          parent: Home,
+          args: ArgsPictures,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture[] | Promise<Picture[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: ArgsPictures,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Picture[] | Promise<Picture[]>;
+        };
 
-    perNight: (
-      parent: Home,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    perNight:
+      | ((
+          parent: Home,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Home,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -784,118 +1664,278 @@ export namespace ReservationResolvers {
     popularity: (parent: Reservation) => parent.popularity
   };
 
-  export type IdResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type TitleResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type TitleResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type AvgPricePerPersonResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type AvgPricePerPersonResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type PicturesResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Picture[] | Promise<Picture[]>;
+  export type PicturesResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Picture[] | Promise<Picture[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture[] | Promise<Picture[]>;
+      };
 
-  export type LocationResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Location | Promise<Location>;
+  export type LocationResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Location | Promise<Location>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>;
+      };
 
-  export type IsCuratedResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type IsCuratedResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type SlugResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type SlugResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type PopularityResolver = (
-    parent: Reservation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PopularityResolver =
+    | ((
+        parent: Reservation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    title: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    title:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    avgPricePerPerson: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    avgPricePerPerson:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    pictures: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Picture[] | Promise<Picture[]>;
+    pictures:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture[] | Promise<Picture[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Picture[] | Promise<Picture[]>;
+        };
 
-    location: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Location | Promise<Location>;
+    location:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Location | Promise<Location>;
+        };
 
-    isCurated: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    isCurated:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    slug: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    slug:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    popularity: (
-      parent: Reservation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    popularity:
+      | ((
+          parent: Reservation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Reservation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -911,104 +1951,244 @@ export namespace NeighbourhoodResolvers {
     popularity: (parent: Neighbourhood) => parent.popularity
   };
 
-  export type IdResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type NameResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type SlugResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type SlugResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type HomePreviewResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Picture | null | Promise<Picture | null>;
+  export type HomePreviewResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Picture | null | Promise<Picture | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture | null | Promise<Picture | null>;
+      };
 
-  export type CityResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => City | Promise<City>;
+  export type CityResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => City | Promise<City>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => City | Promise<City>;
+      };
 
-  export type FeaturedResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type FeaturedResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type PopularityResolver = (
-    parent: Neighbourhood,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PopularityResolver =
+    | ((
+        parent: Neighbourhood,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    name:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    slug: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    slug:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    homePreview: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Picture | null | Promise<Picture | null>;
+    homePreview:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture | null | Promise<Picture | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Picture | null | Promise<Picture | null>;
+        };
 
-    city: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => City | Promise<City>;
+    city:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => City | Promise<City>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => City | Promise<City>;
+        };
 
-    featured: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    featured:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    popularity: (
-      parent: Neighbourhood,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    popularity:
+      | ((
+          parent: Neighbourhood,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Neighbourhood,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -1018,34 +2198,74 @@ export namespace CityResolvers {
     name: (parent: City) => parent.name
   };
 
-  export type IdResolver = (
-    parent: City,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: City,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: City,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: City,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type NameResolver =
+    | ((
+        parent: City,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: City,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    id: (
-      parent: City,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: City,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: City,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: City,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    name:
+      | ((
+          parent: City,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: City,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -1055,34 +2275,74 @@ export namespace ExperiencesByCityResolvers {
     city: (parent: ExperiencesByCity) => parent.city
   };
 
-  export type ExperiencesResolver = (
-    parent: ExperiencesByCity,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Experience[] | Promise<Experience[]>;
+  export type ExperiencesResolver =
+    | ((
+        parent: ExperiencesByCity,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Experience[] | Promise<Experience[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: ExperiencesByCity,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience[] | Promise<Experience[]>;
+      };
 
-  export type CityResolver = (
-    parent: ExperiencesByCity,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => City | Promise<City>;
+  export type CityResolver =
+    | ((
+        parent: ExperiencesByCity,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => City | Promise<City>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: ExperiencesByCity,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => City | Promise<City>;
+      };
 
   export interface Type {
-    experiences: (
-      parent: ExperiencesByCity,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Experience[] | Promise<Experience[]>;
+    experiences:
+      | ((
+          parent: ExperiencesByCity,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience[] | Promise<Experience[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: ExperiencesByCity,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Experience[] | Promise<Experience[]>;
+        };
 
-    city: (
-      parent: ExperiencesByCity,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => City | Promise<City>;
+    city:
+      | ((
+          parent: ExperiencesByCity,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => City | Promise<City>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: ExperiencesByCity,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => City | Promise<City>;
+        };
   }
 }
 
@@ -1092,34 +2352,74 @@ export namespace ViewerResolvers {
     bookings: (parent: Viewer) => parent.bookings
   };
 
-  export type MeResolver = (
-    parent: Viewer,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | Promise<User>;
+  export type MeResolver =
+    | ((
+        parent: Viewer,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | Promise<User>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Viewer,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>;
+      };
 
-  export type BookingsResolver = (
-    parent: Viewer,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Booking[] | Promise<Booking[]>;
+  export type BookingsResolver =
+    | ((
+        parent: Viewer,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Booking[] | Promise<Booking[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Viewer,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking[] | Promise<Booking[]>;
+      };
 
   export interface Type {
-    me: (
-      parent: Viewer,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | Promise<User>;
+    me:
+      | ((
+          parent: Viewer,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Viewer,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | Promise<User>;
+        };
 
-    bookings: (
-      parent: Viewer,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Booking[] | Promise<Booking[]>;
+    bookings:
+      | ((
+          parent: Viewer,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking[] | Promise<Booking[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Viewer,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Booking[] | Promise<Booking[]>;
+        };
   }
 }
 
@@ -1147,286 +2447,686 @@ export namespace UserResolvers {
     updatedAt: (parent: User) => parent.updatedAt
   };
 
-  export type BookingsResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Booking[] | null | Promise<Booking[] | null>;
+  export type BookingsResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Booking[] | null | Promise<Booking[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking[] | null | Promise<Booking[] | null>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type EmailResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type EmailResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type FirstNameResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type FirstNameResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type HostingExperiencesResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Experience[] | null | Promise<Experience[] | null>;
+  export type HostingExperiencesResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Experience[] | null | Promise<Experience[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience[] | null | Promise<Experience[] | null>;
+      };
 
-  export type IdResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IsSuperHostResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type IsSuperHostResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type LastNameResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type LastNameResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LocationResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Location | Promise<Location>;
+  export type LocationResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Location | Promise<Location>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>;
+      };
 
-  export type NotificationsResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Notification[] | null | Promise<Notification[] | null>;
+  export type NotificationsResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Notification[] | null | Promise<Notification[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Notification[] | null | Promise<Notification[] | null>;
+      };
 
-  export type OwnedPlacesResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Place[] | null | Promise<Place[] | null>;
+  export type OwnedPlacesResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Place[] | null | Promise<Place[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Place[] | null | Promise<Place[] | null>;
+      };
 
-  export type PaymentAccountResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+  export type PaymentAccountResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+      };
 
-  export type PhoneResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type PhoneResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type ProfilePictureResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Picture | null | Promise<Picture | null>;
+  export type ProfilePictureResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Picture | null | Promise<Picture | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture | null | Promise<Picture | null>;
+      };
 
-  export type ReceivedMessagesResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Message[] | null | Promise<Message[] | null>;
+  export type ReceivedMessagesResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Message[] | null | Promise<Message[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Message[] | null | Promise<Message[] | null>;
+      };
 
-  export type ResponseRateResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type ResponseRateResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type ResponseTimeResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type ResponseTimeResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type SentMessagesResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Message[] | null | Promise<Message[] | null>;
+  export type SentMessagesResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Message[] | null | Promise<Message[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Message[] | null | Promise<Message[] | null>;
+      };
 
-  export type UpdatedAtResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type UpdatedAtResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type TokenResolver = (
-    parent: User,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type TokenResolver =
+    | ((
+        parent: User,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    bookings: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Booking[] | null | Promise<Booking[] | null>;
+    bookings:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking[] | null | Promise<Booking[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Booking[] | null | Promise<Booking[] | null>;
+        };
 
-    createdAt: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    email: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    email:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    firstName: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    firstName:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    hostingExperiences: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Experience[] | null | Promise<Experience[] | null>;
+    hostingExperiences:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Experience[] | null | Promise<Experience[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Experience[] | null | Promise<Experience[] | null>;
+        };
 
-    id: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    isSuperHost: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    isSuperHost:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    lastName: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    lastName:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    location: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Location | Promise<Location>;
+    location:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Location | Promise<Location>;
+        };
 
-    notifications: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Notification[] | null | Promise<Notification[] | null>;
+    notifications:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Notification[] | null | Promise<Notification[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Notification[] | null | Promise<Notification[] | null>;
+        };
 
-    ownedPlaces: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Place[] | null | Promise<Place[] | null>;
+    ownedPlaces:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Place[] | null | Promise<Place[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Place[] | null | Promise<Place[] | null>;
+        };
 
-    paymentAccount: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+    paymentAccount:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+        };
 
-    phone: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    phone:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    profilePicture: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Picture | null | Promise<Picture | null>;
+    profilePicture:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture | null | Promise<Picture | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Picture | null | Promise<Picture | null>;
+        };
 
-    receivedMessages: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Message[] | null | Promise<Message[] | null>;
+    receivedMessages:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Message[] | null | Promise<Message[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Message[] | null | Promise<Message[] | null>;
+        };
 
-    responseRate: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    responseRate:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    responseTime: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    responseTime:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    sentMessages: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Message[] | null | Promise<Message[] | null>;
+    sentMessages:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Message[] | null | Promise<Message[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Message[] | null | Promise<Message[] | null>;
+        };
 
-    updatedAt: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    updatedAt:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    token: (
-      parent: User,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    token:
+      | ((
+          parent: User,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: User,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -1441,104 +3141,244 @@ export namespace BookingResolvers {
     payment: (parent: Booking) => parent.payment
   };
 
-  export type IdResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type BookeeResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | Promise<User>;
+  export type BookeeResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | Promise<User>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>;
+      };
 
-  export type PlaceResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Place | Promise<Place>;
+  export type PlaceResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Place | Promise<Place>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Place | Promise<Place>;
+      };
 
-  export type StartDateResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type StartDateResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type EndDateResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type EndDateResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type PaymentResolver = (
-    parent: Booking,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Payment | Promise<Payment>;
+  export type PaymentResolver =
+    | ((
+        parent: Booking,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Payment | Promise<Payment>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Payment | Promise<Payment>;
+      };
 
   export interface Type {
-    id: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    createdAt: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    bookee: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | Promise<User>;
+    bookee:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | Promise<User>;
+        };
 
-    place: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Place | Promise<Place>;
+    place:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Place | Promise<Place>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Place | Promise<Place>;
+        };
 
-    startDate: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    startDate:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    endDate: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    endDate:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    payment: (
-      parent: Booking,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Payment | Promise<Payment>;
+    payment:
+      | ((
+          parent: Booking,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Payment | Promise<Payment>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Booking,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Payment | Promise<Payment>;
+        };
   }
 }
 
@@ -1571,314 +3411,754 @@ export namespace PlaceResolvers {
     popularity: (parent: Place) => parent.popularity
   };
 
-  export type IdResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type NameResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type NameResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type SizeResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>;
+  export type SizeResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>;
+      };
 
-  export type ShortDescriptionResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type ShortDescriptionResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type DescriptionResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type DescriptionResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type SlugResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type SlugResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type MaxGuestsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type MaxGuestsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type NumBedroomsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type NumBedroomsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type NumBedsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type NumBedsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type NumBathsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type NumBathsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type ReviewsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Review[] | Promise<Review[]>;
+  export type ReviewsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Review[] | Promise<Review[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Review[] | Promise<Review[]>;
+      };
 
-  export type AmenitiesResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Amenities | Promise<Amenities>;
+  export type AmenitiesResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Amenities | Promise<Amenities>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Amenities | Promise<Amenities>;
+      };
 
-  export type HostResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | Promise<User>;
+  export type HostResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | Promise<User>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>;
+      };
 
-  export type PricingResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Pricing | Promise<Pricing>;
+  export type PricingResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Pricing | Promise<Pricing>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Pricing | Promise<Pricing>;
+      };
 
-  export type LocationResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Location | Promise<Location>;
+  export type LocationResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Location | Promise<Location>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>;
+      };
 
-  export type ViewsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PlaceViews | Promise<PlaceViews>;
+  export type ViewsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PlaceViews | Promise<PlaceViews>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PlaceViews | Promise<PlaceViews>;
+      };
 
-  export type GuestRequirementsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => GuestRequirements | null | Promise<GuestRequirements | null>;
+  export type GuestRequirementsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => GuestRequirements | null | Promise<GuestRequirements | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => GuestRequirements | null | Promise<GuestRequirements | null>;
+      };
 
-  export type PoliciesResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Policies | null | Promise<Policies | null>;
+  export type PoliciesResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Policies | null | Promise<Policies | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Policies | null | Promise<Policies | null>;
+      };
 
-  export type HouseRulesResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => HouseRules | null | Promise<HouseRules | null>;
+  export type HouseRulesResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => HouseRules | null | Promise<HouseRules | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => HouseRules | null | Promise<HouseRules | null>;
+      };
 
-  export type BookingsResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Booking[] | Promise<Booking[]>;
+  export type BookingsResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Booking[] | Promise<Booking[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking[] | Promise<Booking[]>;
+      };
 
-  export type PicturesResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Picture[] | null | Promise<Picture[] | null>;
+  export type PicturesResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Picture[] | null | Promise<Picture[] | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture[] | null | Promise<Picture[] | null>;
+      };
 
-  export type PopularityResolver = (
-    parent: Place,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PopularityResolver =
+    | ((
+        parent: Place,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    name: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    name:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    size: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>;
+    size:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PLACE_SIZES | null | Promise<PLACE_SIZES | null>;
+        };
 
-    shortDescription: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    shortDescription:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    description: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    description:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    slug: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    slug:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    maxGuests: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    maxGuests:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    numBedrooms: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    numBedrooms:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    numBeds: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    numBeds:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    numBaths: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    numBaths:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    reviews: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Review[] | Promise<Review[]>;
+    reviews:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Review[] | Promise<Review[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Review[] | Promise<Review[]>;
+        };
 
-    amenities: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Amenities | Promise<Amenities>;
+    amenities:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Amenities | Promise<Amenities>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Amenities | Promise<Amenities>;
+        };
 
-    host: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | Promise<User>;
+    host:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | Promise<User>;
+        };
 
-    pricing: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Pricing | Promise<Pricing>;
+    pricing:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Pricing | Promise<Pricing>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Pricing | Promise<Pricing>;
+        };
 
-    location: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Location | Promise<Location>;
+    location:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Location | Promise<Location>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Location | Promise<Location>;
+        };
 
-    views: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PlaceViews | Promise<PlaceViews>;
+    views:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PlaceViews | Promise<PlaceViews>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PlaceViews | Promise<PlaceViews>;
+        };
 
-    guestRequirements: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => GuestRequirements | null | Promise<GuestRequirements | null>;
+    guestRequirements:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => GuestRequirements | null | Promise<GuestRequirements | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => GuestRequirements | null | Promise<GuestRequirements | null>;
+        };
 
-    policies: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Policies | null | Promise<Policies | null>;
+    policies:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Policies | null | Promise<Policies | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Policies | null | Promise<Policies | null>;
+        };
 
-    houseRules: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => HouseRules | null | Promise<HouseRules | null>;
+    houseRules:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => HouseRules | null | Promise<HouseRules | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => HouseRules | null | Promise<HouseRules | null>;
+        };
 
-    bookings: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Booking[] | Promise<Booking[]>;
+    bookings:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking[] | Promise<Booking[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Booking[] | Promise<Booking[]>;
+        };
 
-    pictures: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Picture[] | null | Promise<Picture[] | null>;
+    pictures:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Picture[] | null | Promise<Picture[] | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Picture[] | null | Promise<Picture[] | null>;
+        };
 
-    popularity: (
-      parent: Place,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    popularity:
+      | ((
+          parent: Place,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Place,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -1931,580 +4211,1400 @@ export namespace AmenitiesResolvers {
     wirelessInternet: (parent: Amenities) => parent.wirelessInternet
   };
 
-  export type AirConditioningResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type AirConditioningResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type BabyBathResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type BabyBathResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type BabyMonitorResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type BabyMonitorResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type BabysitterRecommendationsResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type BabysitterRecommendationsResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type BathtubResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type BathtubResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type BreakfastResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type BreakfastResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type BuzzerWirelessIntercomResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type BuzzerWirelessIntercomResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type CableTvResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type CableTvResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type ChangingTableResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type ChangingTableResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type ChildrensBooksAndToysResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type ChildrensBooksAndToysResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type ChildrensDinnerwareResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type ChildrensDinnerwareResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type CribResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type CribResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type DoormanResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type DoormanResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type DryerResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type DryerResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type ElevatorResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type ElevatorResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type EssentialsResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type EssentialsResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type FamilyKidFriendlyResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type FamilyKidFriendlyResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type FreeParkingOnPremisesResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type FreeParkingOnPremisesResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type FreeParkingOnStreetResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type FreeParkingOnStreetResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type GymResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type GymResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type HairDryerResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type HairDryerResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type HangersResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type HangersResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type HeatingResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type HeatingResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type HotTubResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type HotTubResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type IdResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IndoorFireplaceResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type IndoorFireplaceResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type InternetResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type InternetResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type IronResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type IronResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type KitchenResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type KitchenResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type LaptopFriendlyWorkspaceResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type LaptopFriendlyWorkspaceResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type PaidParkingOffPremisesResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type PaidParkingOffPremisesResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type PetsAllowedResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type PetsAllowedResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type PoolResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type PoolResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type PrivateEntranceResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type PrivateEntranceResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type ShampooResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type ShampooResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type SmokingAllowedResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type SmokingAllowedResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type SuitableForEventsResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type SuitableForEventsResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type TvResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type TvResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type WasherResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type WasherResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type WheelchairAccessibleResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type WheelchairAccessibleResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type WirelessInternetResolver = (
-    parent: Amenities,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type WirelessInternetResolver =
+    | ((
+        parent: Amenities,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
   export interface Type {
-    airConditioning: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    airConditioning:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    babyBath: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    babyBath:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    babyMonitor: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    babyMonitor:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    babysitterRecommendations: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    babysitterRecommendations:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    bathtub: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    bathtub:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    breakfast: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    breakfast:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    buzzerWirelessIntercom: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    buzzerWirelessIntercom:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    cableTv: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    cableTv:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    changingTable: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    changingTable:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    childrensBooksAndToys: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    childrensBooksAndToys:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    childrensDinnerware: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    childrensDinnerware:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    crib: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    crib:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    doorman: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    doorman:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    dryer: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    dryer:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    elevator: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    elevator:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    essentials: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    essentials:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    familyKidFriendly: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    familyKidFriendly:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    freeParkingOnPremises: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    freeParkingOnPremises:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    freeParkingOnStreet: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    freeParkingOnStreet:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    gym: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    gym:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    hairDryer: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    hairDryer:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    hangers: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    hangers:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    heating: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    heating:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    hotTub: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    hotTub:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    id: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    indoorFireplace: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    indoorFireplace:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    internet: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    internet:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    iron: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    iron:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    kitchen: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    kitchen:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    laptopFriendlyWorkspace: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    laptopFriendlyWorkspace:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    paidParkingOffPremises: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    paidParkingOffPremises:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    petsAllowed: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    petsAllowed:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    pool: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    pool:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    privateEntrance: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    privateEntrance:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    shampoo: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    shampoo:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    smokingAllowed: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    smokingAllowed:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    suitableForEvents: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    suitableForEvents:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    tv: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    tv:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    washer: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    washer:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    wheelchairAccessible: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    wheelchairAccessible:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    wirelessInternet: (
-      parent: Amenities,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    wirelessInternet:
+      | ((
+          parent: Amenities,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Amenities,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
   }
 }
 
@@ -2532,188 +5632,448 @@ export namespace PricingResolvers {
       parent.weeklyDiscount === undefined ? null : parent.weeklyDiscount
   };
 
-  export type AverageMonthlyResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type AverageMonthlyResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type AverageWeeklyResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type AverageWeeklyResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type BasePriceResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type BasePriceResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CleaningFeeResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type CleaningFeeResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type CurrencyResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => CURRENCY | null | Promise<CURRENCY | null>;
+  export type CurrencyResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => CURRENCY | null | Promise<CURRENCY | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => CURRENCY | null | Promise<CURRENCY | null>;
+      };
 
-  export type ExtraGuestsResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type ExtraGuestsResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type IdResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type MonthlyDiscountResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type MonthlyDiscountResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type PerNightResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type PerNightResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type SecurityDepositResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type SecurityDepositResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type SmartPricingResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type SmartPricingResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type WeekendPricingResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type WeekendPricingResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
-  export type WeeklyDiscountResolver = (
-    parent: Pricing,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | null | Promise<number | null>;
+  export type WeeklyDiscountResolver =
+    | ((
+        parent: Pricing,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | null | Promise<number | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>;
+      };
 
   export interface Type {
-    averageMonthly: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    averageMonthly:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    averageWeekly: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    averageWeekly:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    basePrice: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    basePrice:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    cleaningFee: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    cleaningFee:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    currency: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => CURRENCY | null | Promise<CURRENCY | null>;
+    currency:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => CURRENCY | null | Promise<CURRENCY | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => CURRENCY | null | Promise<CURRENCY | null>;
+        };
 
-    extraGuests: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    extraGuests:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    id: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    monthlyDiscount: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    monthlyDiscount:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    perNight: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    perNight:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    securityDeposit: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    securityDeposit:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    smartPricing: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    smartPricing:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    weekendPricing: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    weekendPricing:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
 
-    weeklyDiscount: (
-      parent: Pricing,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | null | Promise<number | null>;
+    weeklyDiscount:
+      | ((
+          parent: Pricing,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | null | Promise<number | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Pricing,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | null | Promise<number | null>;
+        };
   }
 }
 
@@ -2723,34 +6083,74 @@ export namespace PlaceViewsResolvers {
     lastWeek: (parent: PlaceViews) => parent.lastWeek
   };
 
-  export type IdResolver = (
-    parent: PlaceViews,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: PlaceViews,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PlaceViews,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LastWeekResolver = (
-    parent: PlaceViews,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type LastWeekResolver =
+    | ((
+        parent: PlaceViews,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PlaceViews,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    id: (
-      parent: PlaceViews,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: PlaceViews,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PlaceViews,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    lastWeek: (
-      parent: PlaceViews,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    lastWeek:
+      | ((
+          parent: PlaceViews,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PlaceViews,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -2764,62 +6164,142 @@ export namespace GuestRequirementsResolvers {
       parent.recommendationsFromOtherHosts
   };
 
-  export type GovIssuedIdResolver = (
-    parent: GuestRequirements,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type GovIssuedIdResolver =
+    | ((
+        parent: GuestRequirements,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type GuestTripInformationResolver = (
-    parent: GuestRequirements,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type GuestTripInformationResolver =
+    | ((
+        parent: GuestRequirements,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
-  export type IdResolver = (
-    parent: GuestRequirements,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: GuestRequirements,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type RecommendationsFromOtherHostsResolver = (
-    parent: GuestRequirements,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type RecommendationsFromOtherHostsResolver =
+    | ((
+        parent: GuestRequirements,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
   export interface Type {
-    govIssuedId: (
-      parent: GuestRequirements,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    govIssuedId:
+      | ((
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: GuestRequirements,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    guestTripInformation: (
-      parent: GuestRequirements,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    guestTripInformation:
+      | ((
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: GuestRequirements,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
 
-    id: (
-      parent: GuestRequirements,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: GuestRequirements,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    recommendationsFromOtherHosts: (
-      parent: GuestRequirements,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    recommendationsFromOtherHosts:
+      | ((
+          parent: GuestRequirements,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: GuestRequirements,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
   }
 }
 
@@ -2833,90 +6313,210 @@ export namespace PoliciesResolvers {
     updatedAt: (parent: Policies) => parent.updatedAt
   };
 
-  export type CheckInEndTimeResolver = (
-    parent: Policies,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type CheckInEndTimeResolver =
+    | ((
+        parent: Policies,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CheckInStartTimeResolver = (
-    parent: Policies,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type CheckInStartTimeResolver =
+    | ((
+        parent: Policies,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CheckoutTimeResolver = (
-    parent: Policies,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type CheckoutTimeResolver =
+    | ((
+        parent: Policies,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: Policies,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: Policies,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: Policies,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Policies,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type UpdatedAtResolver = (
-    parent: Policies,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type UpdatedAtResolver =
+    | ((
+        parent: Policies,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    checkInEndTime: (
-      parent: Policies,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    checkInEndTime:
+      | ((
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Policies,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    checkInStartTime: (
-      parent: Policies,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    checkInStartTime:
+      | ((
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Policies,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    checkoutTime: (
-      parent: Policies,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    checkoutTime:
+      | ((
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Policies,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    createdAt: (
-      parent: Policies,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Policies,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: Policies,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Policies,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    updatedAt: (
-      parent: Policies,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    updatedAt:
+      | ((
+          parent: Policies,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Policies,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -2945,132 +6545,312 @@ export namespace HouseRulesResolvers {
     updatedAt: (parent: HouseRules) => parent.updatedAt
   };
 
-  export type AdditionalRulesResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | null | Promise<string | null>;
+  export type AdditionalRulesResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | null | Promise<string | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type PartiesAndEventsAllowedResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type PartiesAndEventsAllowedResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type PetsAllowedResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type PetsAllowedResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type SmokingAllowedResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type SmokingAllowedResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type SuitableForChildrenResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type SuitableForChildrenResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type SuitableForInfantsResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | null | Promise<boolean | null>;
+  export type SuitableForInfantsResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | null | Promise<boolean | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>;
+      };
 
-  export type UpdatedAtResolver = (
-    parent: HouseRules,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type UpdatedAtResolver =
+    | ((
+        parent: HouseRules,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    additionalRules: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | null | Promise<string | null>;
+    additionalRules:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | null | Promise<string | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | null | Promise<string | null>;
+        };
 
-    createdAt: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    partiesAndEventsAllowed: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    partiesAndEventsAllowed:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    petsAllowed: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    petsAllowed:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    smokingAllowed: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    smokingAllowed:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    suitableForChildren: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    suitableForChildren:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    suitableForInfants: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | null | Promise<boolean | null>;
+    suitableForInfants:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | null | Promise<boolean | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | null | Promise<boolean | null>;
+        };
 
-    updatedAt: (
-      parent: HouseRules,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    updatedAt:
+      | ((
+          parent: HouseRules,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: HouseRules,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -3083,76 +6863,176 @@ export namespace PaymentResolvers {
     serviceFee: (parent: Payment) => parent.serviceFee
   };
 
-  export type BookingResolver = (
-    parent: Payment,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Booking | Promise<Booking>;
+  export type BookingResolver =
+    | ((
+        parent: Payment,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Booking | Promise<Booking>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking | Promise<Booking>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: Payment,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: Payment,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: Payment,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Payment,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type PaymentMethodResolver = (
-    parent: Payment,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PaymentAccount | Promise<PaymentAccount>;
+  export type PaymentMethodResolver =
+    | ((
+        parent: Payment,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PaymentAccount | Promise<PaymentAccount>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount | Promise<PaymentAccount>;
+      };
 
-  export type ServiceFeeResolver = (
-    parent: Payment,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type ServiceFeeResolver =
+    | ((
+        parent: Payment,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
   export interface Type {
-    booking: (
-      parent: Payment,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Booking | Promise<Booking>;
+    booking:
+      | ((
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Booking | Promise<Booking>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Payment,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Booking | Promise<Booking>;
+        };
 
-    createdAt: (
-      parent: Payment,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Payment,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: Payment,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Payment,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    paymentMethod: (
-      parent: Payment,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PaymentAccount | Promise<PaymentAccount>;
+    paymentMethod:
+      | ((
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount | Promise<PaymentAccount>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Payment,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PaymentAccount | Promise<PaymentAccount>;
+        };
 
-    serviceFee: (
-      parent: Payment,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    serviceFee:
+      | ((
+          parent: Payment,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Payment,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
   }
 }
 
@@ -3170,104 +7050,253 @@ export namespace PaymentAccountResolvers {
       parent.creditcard === undefined ? null : parent.creditcard
   };
 
-  export type IdResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type TypeResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>;
+  export type TypeResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>;
+      };
 
-  export type UserResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | Promise<User>;
+  export type UserResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | Promise<User>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>;
+      };
 
-  export type PaymentsResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => Payment[] | Promise<Payment[]>;
+  export type PaymentsResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => Payment[] | Promise<Payment[]>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Payment[] | Promise<Payment[]>;
+      };
 
-  export type PaypalResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PaypalInformation | null | Promise<PaypalInformation | null>;
+  export type PaypalResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PaypalInformation | null | Promise<PaypalInformation | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaypalInformation | null | Promise<PaypalInformation | null>;
+      };
 
-  export type CreditcardResolver = (
-    parent: PaymentAccount,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => CreditCardInformation | null | Promise<CreditCardInformation | null>;
+  export type CreditcardResolver =
+    | ((
+        parent: PaymentAccount,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => CreditCardInformation | null | Promise<CreditCardInformation | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | CreditCardInformation
+          | null
+          | Promise<CreditCardInformation | null>;
+      };
 
   export interface Type {
-    id: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    createdAt: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    type: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>;
+    type:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PAYMENT_PROVIDER | null | Promise<PAYMENT_PROVIDER | null>;
+        };
 
-    user: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | Promise<User>;
+    user:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | Promise<User>;
+        };
 
-    payments: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => Payment[] | Promise<Payment[]>;
+    payments:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => Payment[] | Promise<Payment[]>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => Payment[] | Promise<Payment[]>;
+        };
 
-    paypal: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PaypalInformation | null | Promise<PaypalInformation | null>;
+    paypal:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaypalInformation | null | Promise<PaypalInformation | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PaypalInformation | null | Promise<PaypalInformation | null>;
+        };
 
-    creditcard: (
-      parent: PaymentAccount,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => CreditCardInformation | null | Promise<CreditCardInformation | null>;
+    creditcard:
+      | ((
+          parent: PaymentAccount,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) =>
+          | CreditCardInformation
+          | null
+          | Promise<CreditCardInformation | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaymentAccount,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) =>
+            | CreditCardInformation
+            | null
+            | Promise<CreditCardInformation | null>;
+        };
   }
 }
 
@@ -3279,62 +7308,142 @@ export namespace PaypalInformationResolvers {
     paymentAccount: (parent: PaypalInformation) => parent.paymentAccount
   };
 
-  export type CreatedAtResolver = (
-    parent: PaypalInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: PaypalInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type EmailResolver = (
-    parent: PaypalInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type EmailResolver =
+    | ((
+        parent: PaypalInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: PaypalInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: PaypalInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type PaymentAccountResolver = (
-    parent: PaypalInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PaymentAccount | Promise<PaymentAccount>;
+  export type PaymentAccountResolver =
+    | ((
+        parent: PaypalInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PaymentAccount | Promise<PaymentAccount>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount | Promise<PaymentAccount>;
+      };
 
   export interface Type {
-    createdAt: (
-      parent: PaypalInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaypalInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    email: (
-      parent: PaypalInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    email:
+      | ((
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaypalInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: PaypalInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaypalInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    paymentAccount: (
-      parent: PaypalInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PaymentAccount | Promise<PaymentAccount>;
+    paymentAccount:
+      | ((
+          parent: PaypalInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount | Promise<PaymentAccount>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: PaypalInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PaymentAccount | Promise<PaymentAccount>;
+        };
   }
 }
 
@@ -3354,160 +7463,380 @@ export namespace CreditCardInformationResolvers {
     securityCode: (parent: CreditCardInformation) => parent.securityCode
   };
 
-  export type CardNumberResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CardNumberResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type CountryResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CountryResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type CreatedAtResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type ExpiresOnMonthResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type ExpiresOnMonthResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type ExpiresOnYearResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => number | Promise<number>;
+  export type ExpiresOnYearResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => number | Promise<number>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>;
+      };
 
-  export type FirstNameResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type FirstNameResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LastNameResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type LastNameResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type PaymentAccountResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => PaymentAccount | null | Promise<PaymentAccount | null>;
+  export type PaymentAccountResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => PaymentAccount | null | Promise<PaymentAccount | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount | null | Promise<PaymentAccount | null>;
+      };
 
-  export type PostalCodeResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type PostalCodeResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type SecurityCodeResolver = (
-    parent: CreditCardInformation,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type SecurityCodeResolver =
+    | ((
+        parent: CreditCardInformation,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    cardNumber: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    cardNumber:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    country: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    country:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    createdAt: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    expiresOnMonth: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    expiresOnMonth:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    expiresOnYear: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => number | Promise<number>;
+    expiresOnYear:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => number | Promise<number>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => number | Promise<number>;
+        };
 
-    firstName: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    firstName:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    lastName: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    lastName:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    paymentAccount: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => PaymentAccount | null | Promise<PaymentAccount | null>;
+    paymentAccount:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => PaymentAccount | null | Promise<PaymentAccount | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => PaymentAccount | null | Promise<PaymentAccount | null>;
+        };
 
-    postalCode: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    postalCode:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    securityCode: (
-      parent: CreditCardInformation,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    securityCode:
+      | ((
+          parent: CreditCardInformation,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: CreditCardInformation,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -3522,90 +7851,210 @@ export namespace NotificationResolvers {
     user: (parent: Notification) => parent.user
   };
 
-  export type CreatedAtResolver = (
-    parent: Notification,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: Notification,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: Notification,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Notification,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type LinkResolver = (
-    parent: Notification,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type LinkResolver =
+    | ((
+        parent: Notification,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type ReadDateResolver = (
-    parent: Notification,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type ReadDateResolver =
+    | ((
+        parent: Notification,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type TypeResolver = (
-    parent: Notification,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>;
+  export type TypeResolver =
+    | ((
+        parent: Notification,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>;
+      };
 
-  export type UserResolver = (
-    parent: Notification,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | Promise<User>;
+  export type UserResolver =
+    | ((
+        parent: Notification,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | Promise<User>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>;
+      };
 
   export interface Type {
-    createdAt: (
-      parent: Notification,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Notification,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: Notification,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Notification,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    link: (
-      parent: Notification,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    link:
+      | ((
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Notification,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    readDate: (
-      parent: Notification,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    readDate:
+      | ((
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Notification,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    type: (
-      parent: Notification,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>;
+    type:
+      | ((
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Notification,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => NOTIFICATION_TYPE | null | Promise<NOTIFICATION_TYPE | null>;
+        };
 
-    user: (
-      parent: Notification,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | Promise<User>;
+    user:
+      | ((
+          parent: Notification,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Notification,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | Promise<User>;
+        };
   }
 }
 
@@ -3617,62 +8066,142 @@ export namespace MessageResolvers {
     readAt: (parent: Message) => parent.readAt
   };
 
-  export type CreatedAtResolver = (
-    parent: Message,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type CreatedAtResolver =
+    | ((
+        parent: Message,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type DeliveredAtResolver = (
-    parent: Message,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type DeliveredAtResolver =
+    | ((
+        parent: Message,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type IdResolver = (
-    parent: Message,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type IdResolver =
+    | ((
+        parent: Message,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type ReadAtResolver = (
-    parent: Message,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type ReadAtResolver =
+    | ((
+        parent: Message,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
   export interface Type {
-    createdAt: (
-      parent: Message,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    createdAt:
+      | ((
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Message,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    deliveredAt: (
-      parent: Message,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    deliveredAt:
+      | ((
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Message,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    id: (
-      parent: Message,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    id:
+      | ((
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Message,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    readAt: (
-      parent: Message,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    readAt:
+      | ((
+          parent: Message,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: Message,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
   }
 }
 
@@ -3710,62 +8239,142 @@ export namespace MutationResolvers {
     numGuests: number;
   }
 
-  export type SignupResolver = (
-    parent: undefined,
-    args: ArgsSignup,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => AuthPayload | Promise<AuthPayload>;
+  export type SignupResolver =
+    | ((
+        parent: undefined,
+        args: ArgsSignup,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => AuthPayload | Promise<AuthPayload>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsSignup,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AuthPayload | Promise<AuthPayload>;
+      };
 
-  export type LoginResolver = (
-    parent: undefined,
-    args: ArgsLogin,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => AuthPayload | Promise<AuthPayload>;
+  export type LoginResolver =
+    | ((
+        parent: undefined,
+        args: ArgsLogin,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => AuthPayload | Promise<AuthPayload>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsLogin,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AuthPayload | Promise<AuthPayload>;
+      };
 
-  export type AddPaymentMethodResolver = (
-    parent: undefined,
-    args: ArgsAddPaymentMethod,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => MutationResult | Promise<MutationResult>;
+  export type AddPaymentMethodResolver =
+    | ((
+        parent: undefined,
+        args: ArgsAddPaymentMethod,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => MutationResult | Promise<MutationResult>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsAddPaymentMethod,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => MutationResult | Promise<MutationResult>;
+      };
 
-  export type BookResolver = (
-    parent: undefined,
-    args: ArgsBook,
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => MutationResult | Promise<MutationResult>;
+  export type BookResolver =
+    | ((
+        parent: undefined,
+        args: ArgsBook,
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => MutationResult | Promise<MutationResult>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: undefined,
+          args: ArgsBook,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => MutationResult | Promise<MutationResult>;
+      };
 
   export interface Type {
-    signup: (
-      parent: undefined,
-      args: ArgsSignup,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => AuthPayload | Promise<AuthPayload>;
+    signup:
+      | ((
+          parent: undefined,
+          args: ArgsSignup,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AuthPayload | Promise<AuthPayload>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsSignup,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => AuthPayload | Promise<AuthPayload>;
+        };
 
-    login: (
-      parent: undefined,
-      args: ArgsLogin,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => AuthPayload | Promise<AuthPayload>;
+    login:
+      | ((
+          parent: undefined,
+          args: ArgsLogin,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => AuthPayload | Promise<AuthPayload>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsLogin,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => AuthPayload | Promise<AuthPayload>;
+        };
 
-    addPaymentMethod: (
-      parent: undefined,
-      args: ArgsAddPaymentMethod,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => MutationResult | Promise<MutationResult>;
+    addPaymentMethod:
+      | ((
+          parent: undefined,
+          args: ArgsAddPaymentMethod,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => MutationResult | Promise<MutationResult>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsAddPaymentMethod,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => MutationResult | Promise<MutationResult>;
+        };
 
-    book: (
-      parent: undefined,
-      args: ArgsBook,
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => MutationResult | Promise<MutationResult>;
+    book:
+      | ((
+          parent: undefined,
+          args: ArgsBook,
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => MutationResult | Promise<MutationResult>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: undefined,
+            args: ArgsBook,
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => MutationResult | Promise<MutationResult>;
+        };
   }
 }
 
@@ -3775,34 +8384,74 @@ export namespace AuthPayloadResolvers {
     user: (parent: AuthPayload) => parent.user
   };
 
-  export type TokenResolver = (
-    parent: AuthPayload,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => string | Promise<string>;
+  export type TokenResolver =
+    | ((
+        parent: AuthPayload,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => string | Promise<string>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: AuthPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>;
+      };
 
-  export type UserResolver = (
-    parent: AuthPayload,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => User | Promise<User>;
+  export type UserResolver =
+    | ((
+        parent: AuthPayload,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => User | Promise<User>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: AuthPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>;
+      };
 
   export interface Type {
-    token: (
-      parent: AuthPayload,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => string | Promise<string>;
+    token:
+      | ((
+          parent: AuthPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => string | Promise<string>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: AuthPayload,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => string | Promise<string>;
+        };
 
-    user: (
-      parent: AuthPayload,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => User | Promise<User>;
+    user:
+      | ((
+          parent: AuthPayload,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => User | Promise<User>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: AuthPayload,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => User | Promise<User>;
+        };
   }
 }
 
@@ -3811,20 +8460,40 @@ export namespace MutationResultResolvers {
     success: (parent: MutationResult) => parent.success
   };
 
-  export type SuccessResolver = (
-    parent: MutationResult,
-    args: {},
-    ctx: Context,
-    info: GraphQLResolveInfo
-  ) => boolean | Promise<boolean>;
+  export type SuccessResolver =
+    | ((
+        parent: MutationResult,
+        args: {},
+        ctx: Context,
+        info: GraphQLResolveInfo
+      ) => boolean | Promise<boolean>)
+    | {
+        fragment: string;
+        resolver: (
+          parent: MutationResult,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>;
+      };
 
   export interface Type {
-    success: (
-      parent: MutationResult,
-      args: {},
-      ctx: Context,
-      info: GraphQLResolveInfo
-    ) => boolean | Promise<boolean>;
+    success:
+      | ((
+          parent: MutationResult,
+          args: {},
+          ctx: Context,
+          info: GraphQLResolveInfo
+        ) => boolean | Promise<boolean>)
+      | {
+          fragment: string;
+          resolver: (
+            parent: MutationResult,
+            args: {},
+            ctx: Context,
+            info: GraphQLResolveInfo
+          ) => boolean | Promise<boolean>;
+        };
   }
 }
 


### PR DESCRIPTION
Will close #428

I have chosen to continue down the type-duplication route for this feature so that we can avoid a new round of design consideration (prior: #236, #285) regarding use of generics that might block this feature unnecessarily.