### PR TITLE
feat: allow disabling default resolvers

### DIFF
--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -14,6 +14,7 @@ The configuration file must be called **`graphqlgen.yml`**.
 - `resolver-scaffolding`: An object with two properties
   - `output`: Specifies where the scaffolded resolvers should be located. Must point to a **directory**.
   - `layout`: Specifies the [_layout_](#layouts) for the generated files. Possible values: `file-per-type` (more layouts [coming soon](https://github.com/prisma/graphqlgen/issues/106): `single-file`, `file-per-type-classes`, `single-file-classes`).
+- `default-resolvers`: A boolean dictating if default resolvers will be generated or not. Defaults to `true`.
 
 Whether a property is required or not depends on whether you're doing [Generation](#generation) or [Scaffolding](#scaffolding).
 

--- a/packages/graphqlgen-json-schema/src/definition.ts
+++ b/packages/graphqlgen-json-schema/src/definition.ts
@@ -5,6 +5,7 @@ export interface GraphQLGenDefinition {
   models: Models
   output: string
   ['resolver-scaffolding']?: ResolverScaffolding
+  ['default-resolvers']?: boolean
 }
 
 export interface Models {

--- a/packages/graphqlgen/package.json
+++ b/packages/graphqlgen/package.json
@@ -44,7 +44,7 @@
     "glob": "^7.1.3",
     "graphql": "^0.13.0 || ^14.0.0",
     "graphql-import": "0.7.1",
-    "graphqlgen-json-schema": "0.2.12",
+    "graphqlgen-json-schema": "0.6.0-rc3",
     "js-yaml": "3.12.1",
     "mkdirp": "0.5.1",
     "prettier": "1.16.2",

--- a/packages/graphqlgen/src/generators/flow/generator.ts
+++ b/packages/graphqlgen/src/generators/flow/generator.ts
@@ -171,7 +171,8 @@ function renderNamespace(
 
   return `\
     // Types for ${typeName}
-    ${renderDefaultResolvers(type, args, `${typeName}_defaultResolvers`)}
+    ${args.defaultResolversEnabled &&
+      renderDefaultResolvers(type, args, `${typeName}_defaultResolvers`)}
 
     ${renderInputTypeInterfaces(
       type,

--- a/packages/graphqlgen/src/generators/flow/generator.ts
+++ b/packages/graphqlgen/src/generators/flow/generator.ts
@@ -171,8 +171,11 @@ function renderNamespace(
 
   return `\
     // Types for ${typeName}
-    ${args.defaultResolversEnabled &&
-      renderDefaultResolvers(type, args, `${typeName}_defaultResolvers`)}
+    ${
+      args.defaultResolversEnabled
+        ? renderDefaultResolvers(type, args, `${typeName}_defaultResolvers`)
+        : ''
+    }
 
     ${renderInputTypeInterfaces(
       type,

--- a/packages/graphqlgen/src/generators/flow/scaffolder.ts
+++ b/packages/graphqlgen/src/generators/flow/scaffolder.ts
@@ -92,11 +92,15 @@ function renderResolvers(
   const modelFields = fieldsFromModelDefinition(model.definition)
   const upperTypeName = upperFirst(type.name)
   const code = `/* @flow */
-import { ${upperTypeName}_defaultResolvers } from '[TEMPLATE-INTERFACES-PATH]'
+${
+  args.defaultResolversEnabled
+    ? `import { ${upperTypeName}_defaultResolvers } from '[TEMPLATE-INTERFACES-PATH]'`
+    : ''
+}
 import type { ${upperTypeName}_Resolvers } from '[TEMPLATE-INTERFACES-PATH]'
 
 export const ${type.name}: ${upperTypeName}_Resolvers = {
-  ...${upperTypeName}_defaultResolvers,
+  ${args.defaultResolversEnabled ? `...${upperTypeName}_defaultResolvers,` : ''}
   ${type.fields
     .filter(graphQLField =>
       shouldScaffoldFieldResolver(graphQLField, modelFields, args),

--- a/packages/graphqlgen/src/generators/typescript/generator.ts
+++ b/packages/graphqlgen/src/generators/typescript/generator.ts
@@ -299,7 +299,8 @@ function renderNamespace(
   return `\
     export namespace ${graphQLTypeObject.name}Resolvers {
 
-    ${renderDefaultResolvers(graphQLTypeObject, args, 'defaultResolvers')}
+    ${args.defaultResolversEnabled &&
+      renderDefaultResolvers(graphQLTypeObject, args, 'defaultResolvers')}
 
     ${renderInputTypeInterfaces(
       graphQLTypeObject,

--- a/packages/graphqlgen/src/generators/typescript/generator.ts
+++ b/packages/graphqlgen/src/generators/typescript/generator.ts
@@ -299,8 +299,11 @@ function renderNamespace(
   return `\
     export namespace ${graphQLTypeObject.name}Resolvers {
 
-    ${args.defaultResolversEnabled &&
-      renderDefaultResolvers(graphQLTypeObject, args, 'defaultResolvers')}
+    ${
+      args.defaultResolversEnabled
+        ? renderDefaultResolvers(graphQLTypeObject, args, 'defaultResolvers')
+        : ''
+    }
 
     ${renderInputTypeInterfaces(
       graphQLTypeObject,

--- a/packages/graphqlgen/src/generators/typescript/scaffolder.ts
+++ b/packages/graphqlgen/src/generators/typescript/scaffolder.ts
@@ -26,7 +26,11 @@ function renderResolvers(
   import { ${type.name}Resolvers } from '[TEMPLATE-INTERFACES-PATH]'
 
   export const ${type.name}: ${type.name}Resolvers.Type = {
-    ...${type.name}Resolvers.defaultResolvers,
+    ${
+      args.defaultResolversEnabled
+        ? `...${type.name}Resolvers.defaultResolvers,`
+        : ''
+    }
     ${type.fields
       .filter(field => shouldScaffoldFieldResolver(field, modelFields, args))
       .map(
@@ -57,7 +61,10 @@ function renderPolyResolvers(
   return { path: `${type.name}.ts`, force: false, code }
 }
 
-function renderParentResolvers(type: GraphQLTypeObject): CodeFileLike {
+function renderParentResolvers(
+  type: GraphQLTypeObject,
+  args: GenerateArgs,
+): CodeFileLike {
   const code = `\
   // This resolver file was scaffolded by github.com/prisma/graphqlgen, DO NOT EDIT.
   // Please do not import this file directly but copy & paste to your application code.
@@ -65,7 +72,11 @@ function renderParentResolvers(type: GraphQLTypeObject): CodeFileLike {
   import { ${type.name}Resolvers } from '[TEMPLATE-INTERFACES-PATH]'
 
   export const ${type.name}: ${type.name}Resolvers.Type = {
-    ...${type.name}Resolvers.defaultResolvers,
+    ${
+      args.defaultResolversEnabled
+        ? `...${type.name}Resolvers.defaultResolvers,`
+        : ''
+    }
     ${type.fields.map(field => {
       if (type.name === 'Subscription') {
         return `${field.name}: {
@@ -126,7 +137,7 @@ export function generate(args: GenerateArgs): CodeFileLike[] {
     args.types
       .filter(type => type.type.isObject)
       .filter(type => isParentType(type.name))
-      .map(renderParentResolvers),
+      .map(type => renderParentResolvers(type, args)),
   )
 
   files.push({

--- a/packages/graphqlgen/src/index.ts
+++ b/packages/graphqlgen/src/index.ts
@@ -91,19 +91,23 @@ type CodeGenResult = {
 }
 
 export function generateCode(codeGenArgs: CodeGenArgs): CodeGenResult {
-  const { schema } = codeGenArgs
-
   const generateArgs: GenerateArgs = {
-    ...schema,
+    enums: codeGenArgs.schema.enums,
+    interfaces: codeGenArgs.schema.interfaces,
+    types: codeGenArgs.schema.types,
+    unions: codeGenArgs.schema.unions,
+    modelMap: codeGenArgs.modelMap!,
     context: parseContext(
       codeGenArgs.config.context,
       codeGenArgs.config.output,
     ),
-    modelMap: codeGenArgs.modelMap!,
+    defaultResolvers:
+      typeof codeGenArgs.config['default-resolvers'] === 'boolean'
+        ? codeGenArgs.config['default-resolvers']
+        : true,
   }
 
   const generatedTypes = generateTypes(generateArgs, codeGenArgs)
-
   const generatedResolvers = codeGenArgs.config['resolver-scaffolding']
     ? generateResolvers(generateArgs, codeGenArgs)
     : undefined

--- a/packages/graphqlgen/src/index.ts
+++ b/packages/graphqlgen/src/index.ts
@@ -101,7 +101,7 @@ export function generateCode(codeGenArgs: CodeGenArgs): CodeGenResult {
       codeGenArgs.config.context,
       codeGenArgs.config.output,
     ),
-    defaultResolvers:
+    defaultResolversEnabled:
       typeof codeGenArgs.config['default-resolvers'] === 'boolean'
         ? codeGenArgs.config['default-resolvers']
         : true,

--- a/packages/graphqlgen/src/types.ts
+++ b/packages/graphqlgen/src/types.ts
@@ -14,6 +14,7 @@ export interface GenerateArgs {
   unions: GraphQLUnionObject[]
   context?: ContextDefinition
   modelMap: ModelMap
+  defaultResolvers: boolean
 }
 
 export interface ModelMap {

--- a/packages/graphqlgen/src/types.ts
+++ b/packages/graphqlgen/src/types.ts
@@ -14,7 +14,7 @@ export interface GenerateArgs {
   unions: GraphQLUnionObject[]
   context?: ContextDefinition
   modelMap: ModelMap
-  defaultResolvers: boolean
+  defaultResolversEnabled: boolean
 }
 
 export interface ModelMap {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,7 +1800,7 @@ graphql-import@0.7.1:
     lodash "^4.17.4"
     resolve-from "^4.0.0"
 
-graphql-tag@^2.10.1:
+graphql-tag@2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
@@ -1811,11 +1811,6 @@ graphql-tag@^2.10.1:
   integrity sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==
   dependencies:
     iterall "^1.2.2"
-
-graphqlgen-json-schema@0.2.12:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/graphqlgen-json-schema/-/graphqlgen-json-schema-0.2.12.tgz#445a2da9839a460841d729fba5941fd3007249c2"
-  integrity sha512-Q87J16Di8mWLJV2Xd5IG+13ec6U6hZJHSlsCGfnQz4CoM7K8wiHcXeMb4be9Cru4a43PBOuOI/qjkwCqdX2mEg==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Will close #350

This is useful if a graphql server is not making use of default resolvers, and therefore probably also has significantly different models. By removing default resolvers from generated code we allow such developers to edit their models without needing to re-run graphqlgen.