### PR TITLE
Support iterable return types

### DIFF
--- a/packages/graphqlgen/tests/flow/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/tests/flow/__snapshots__/basic.test.ts.snap
@@ -324,14 +324,14 @@ export type Query_Custom_array_nullable_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+) => Iterable<Number | null> | null | Promise<Iterable<Number | null> | null>;
 
 export type Query_Custom_array_required_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<Number | null> | Promise<Array<Number | null>>;
+) => Iterable<Number | null> | Promise<Iterable<Number | null>>;
 
 export type Query_Custom_with_arg_Resolver = (
   parent: {},
@@ -366,14 +366,14 @@ export type Query_Scalar_array_nullable_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+) => Iterable<boolean | null> | null | Promise<Iterable<boolean | null> | null>;
 
 export type Query_Scalar_array_required_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<boolean | null> | Promise<Array<boolean | null>>;
+) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
 
 export type Query_Scalar_with_arg_Resolver = (
   parent: {},
@@ -416,14 +416,14 @@ export interface Query_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+  ) => Iterable<Number | null> | null | Promise<Iterable<Number | null> | null>;
 
   custom_array_required: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<Number | null> | Promise<Array<Number | null>>;
+  ) => Iterable<Number | null> | Promise<Iterable<Number | null>>;
 
   custom_with_arg: (
     parent: {},
@@ -458,14 +458,17 @@ export interface Query_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+  ) =>
+    | Iterable<boolean | null>
+    | null
+    | Promise<Iterable<boolean | null> | null>;
 
   scalar_array_required: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+  ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
 
   scalar_with_arg: (
     parent: {},
@@ -629,7 +632,7 @@ export type Query_Users_Resolver = (
   args: Query_Args_Users,
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+) => Iterable<Student | Professor> | Promise<Iterable<Student | Professor>>;
 
 export interface Query_Resolvers {
   users: (
@@ -637,7 +640,7 @@ export interface Query_Resolvers {
     args: Query_Args_Users,
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+  ) => Iterable<Student | Professor> | Promise<Iterable<Student | Professor>>;
 }
 
 // Types for Student
@@ -984,14 +987,17 @@ export type Query_Custom_array_nullable_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<NumberNode | null> | null | Promise<Array<NumberNode | null> | null>;
+) =>
+  | Iterable<NumberNode | null>
+  | null
+  | Promise<Iterable<NumberNode | null> | null>;
 
 export type Query_Custom_array_required_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+) => Iterable<NumberNode | null> | Promise<Iterable<NumberNode | null>>;
 
 export type Query_Custom_with_arg_Resolver = (
   parent: {},
@@ -1026,14 +1032,14 @@ export type Query_Scalar_array_nullable_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+) => Iterable<boolean | null> | null | Promise<Iterable<boolean | null> | null>;
 
 export type Query_Scalar_array_required_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Array<boolean | null> | Promise<Array<boolean | null>>;
+) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
 
 export type Query_Scalar_with_arg_Resolver = (
   parent: {},
@@ -1077,16 +1083,16 @@ export interface Query_Resolvers {
     ctx: Context,
     info: GraphQLResolveInfo
   ) =>
-    | Array<NumberNode | null>
+    | Iterable<NumberNode | null>
     | null
-    | Promise<Array<NumberNode | null> | null>;
+    | Promise<Iterable<NumberNode | null> | null>;
 
   custom_array_required: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+  ) => Iterable<NumberNode | null> | Promise<Iterable<NumberNode | null>>;
 
   custom_with_arg: (
     parent: {},
@@ -1121,14 +1127,17 @@ export interface Query_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>;
+  ) =>
+    | Iterable<boolean | null>
+    | null
+    | Promise<Iterable<boolean | null> | null>;
 
   scalar_array_required: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+  ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
 
   scalar_with_arg: (
     parent: {},

--- a/packages/graphqlgen/tests/flow/__snapshots__/large-schema.test.ts.snap
+++ b/packages/graphqlgen/tests/flow/__snapshots__/large-schema.test.ts.snap
@@ -72,42 +72,42 @@ export type Query_TopExperiences_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Experience[] | Promise<Experience[]>;
+) => Iterable<Experience> | Promise<Iterable<Experience>>;
 
 export type Query_TopHomes_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Home[] | Promise<Home[]>;
+) => Iterable<Home> | Promise<Iterable<Home>>;
 
 export type Query_HomesInPriceRange_Resolver = (
   parent: {},
   args: Query_Args_HomesInPriceRange,
   ctx: Context,
   info: GraphQLResolveInfo
-) => Home[] | Promise<Home[]>;
+) => Iterable<Home> | Promise<Iterable<Home>>;
 
 export type Query_TopReservations_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Reservation[] | Promise<Reservation[]>;
+) => Iterable<Reservation> | Promise<Iterable<Reservation>>;
 
 export type Query_FeaturedDestinations_Resolver = (
   parent: {},
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Neighbourhood[] | Promise<Neighbourhood[]>;
+) => Iterable<Neighbourhood> | Promise<Iterable<Neighbourhood>>;
 
 export type Query_ExperiencesByCity_Resolver = (
   parent: {},
   args: Query_Args_ExperiencesByCity,
   ctx: Context,
   info: GraphQLResolveInfo
-) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+) => Iterable<ExperiencesByCity> | Promise<Iterable<ExperiencesByCity>>;
 
 export type Query_Viewer_Resolver = (
   parent: {},
@@ -129,42 +129,42 @@ export interface Query_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Experience[] | Promise<Experience[]>;
+  ) => Iterable<Experience> | Promise<Iterable<Experience>>;
 
   topHomes: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Home[] | Promise<Home[]>;
+  ) => Iterable<Home> | Promise<Iterable<Home>>;
 
   homesInPriceRange: (
     parent: {},
     args: Query_Args_HomesInPriceRange,
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Home[] | Promise<Home[]>;
+  ) => Iterable<Home> | Promise<Iterable<Home>>;
 
   topReservations: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Reservation[] | Promise<Reservation[]>;
+  ) => Iterable<Reservation> | Promise<Iterable<Reservation>>;
 
   featuredDestinations: (
     parent: {},
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+  ) => Iterable<Neighbourhood> | Promise<Iterable<Neighbourhood>>;
 
   experiencesByCity: (
     parent: {},
     args: Query_Args_ExperiencesByCity,
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+  ) => Iterable<ExperiencesByCity> | Promise<Iterable<ExperiencesByCity>>;
 
   viewer: (
     parent: {},
@@ -234,7 +234,7 @@ export type Experience_Reviews_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Review[] | Promise<Review[]>;
+) => Iterable<Review> | Promise<Iterable<Review>>;
 
 export type Experience_Preview_Resolver = (
   parent: Experience,
@@ -291,7 +291,7 @@ export interface Experience_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Review[] | Promise<Review[]>;
+  ) => Iterable<Review> | Promise<Iterable<Review>>;
 
   preview: (
     parent: Experience,
@@ -706,7 +706,7 @@ export type Home_Pictures_Resolver = (
   args: Home_Args_Pictures,
   ctx: Context,
   info: GraphQLResolveInfo
-) => Picture[] | Promise<Picture[]>;
+) => Iterable<Picture> | Promise<Iterable<Picture>>;
 
 export type Home_PerNight_Resolver = (
   parent: Home,
@@ -756,7 +756,7 @@ export interface Home_Resolvers {
     args: Home_Args_Pictures,
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Picture[] | Promise<Picture[]>;
+  ) => Iterable<Picture> | Promise<Iterable<Picture>>;
 
   perNight: (
     parent: Home,
@@ -804,7 +804,7 @@ export type Reservation_Pictures_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Picture[] | Promise<Picture[]>;
+) => Iterable<Picture> | Promise<Iterable<Picture>>;
 
 export type Reservation_Location_Resolver = (
   parent: Reservation,
@@ -861,7 +861,7 @@ export interface Reservation_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Picture[] | Promise<Picture[]>;
+  ) => Iterable<Picture> | Promise<Iterable<Picture>>;
 
   location: (
     parent: Reservation,
@@ -1051,7 +1051,7 @@ export type ExperiencesByCity_Experiences_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Experience[] | Promise<Experience[]>;
+) => Iterable<Experience> | Promise<Iterable<Experience>>;
 
 export type ExperiencesByCity_City_Resolver = (
   parent: ExperiencesByCity,
@@ -1066,7 +1066,7 @@ export interface ExperiencesByCity_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Experience[] | Promise<Experience[]>;
+  ) => Iterable<Experience> | Promise<Iterable<Experience>>;
 
   city: (
     parent: ExperiencesByCity,
@@ -1094,7 +1094,7 @@ export type Viewer_Bookings_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Booking[] | Promise<Booking[]>;
+) => Iterable<Booking> | Promise<Iterable<Booking>>;
 
 export interface Viewer_Resolvers {
   me: (
@@ -1109,7 +1109,7 @@ export interface Viewer_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Booking[] | Promise<Booking[]>;
+  ) => Iterable<Booking> | Promise<Iterable<Booking>>;
 }
 
 // Types for User
@@ -1141,7 +1141,7 @@ export type User_Bookings_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Booking[] | null | Promise<Booking[] | null>;
+) => Iterable<Booking> | null | Promise<Iterable<Booking> | null>;
 
 export type User_CreatedAt_Resolver = (
   parent: User,
@@ -1169,7 +1169,7 @@ export type User_HostingExperiences_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Experience[] | null | Promise<Experience[] | null>;
+) => Iterable<Experience> | null | Promise<Iterable<Experience> | null>;
 
 export type User_Id_Resolver = (
   parent: User,
@@ -1204,21 +1204,21 @@ export type User_Notifications_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Notification[] | null | Promise<Notification[] | null>;
+) => Iterable<Notification> | null | Promise<Iterable<Notification> | null>;
 
 export type User_OwnedPlaces_Resolver = (
   parent: User,
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Place[] | null | Promise<Place[] | null>;
+) => Iterable<Place> | null | Promise<Iterable<Place> | null>;
 
 export type User_PaymentAccount_Resolver = (
   parent: User,
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+) => Iterable<PaymentAccount> | null | Promise<Iterable<PaymentAccount> | null>;
 
 export type User_Phone_Resolver = (
   parent: User,
@@ -1239,7 +1239,7 @@ export type User_ReceivedMessages_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Message[] | null | Promise<Message[] | null>;
+) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
 
 export type User_ResponseRate_Resolver = (
   parent: User,
@@ -1260,7 +1260,7 @@ export type User_SentMessages_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Message[] | null | Promise<Message[] | null>;
+) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
 
 export type User_UpdatedAt_Resolver = (
   parent: User,
@@ -1282,7 +1282,7 @@ export interface User_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Booking[] | null | Promise<Booking[] | null>;
+  ) => Iterable<Booking> | null | Promise<Iterable<Booking> | null>;
 
   createdAt: (
     parent: User,
@@ -1310,7 +1310,7 @@ export interface User_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Experience[] | null | Promise<Experience[] | null>;
+  ) => Iterable<Experience> | null | Promise<Iterable<Experience> | null>;
 
   id: (
     parent: User,
@@ -1345,21 +1345,24 @@ export interface User_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Notification[] | null | Promise<Notification[] | null>;
+  ) => Iterable<Notification> | null | Promise<Iterable<Notification> | null>;
 
   ownedPlaces: (
     parent: User,
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Place[] | null | Promise<Place[] | null>;
+  ) => Iterable<Place> | null | Promise<Iterable<Place> | null>;
 
   paymentAccount: (
     parent: User,
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+  ) =>
+    | Iterable<PaymentAccount>
+    | null
+    | Promise<Iterable<PaymentAccount> | null>;
 
   phone: (
     parent: User,
@@ -1380,7 +1383,7 @@ export interface User_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Message[] | null | Promise<Message[] | null>;
+  ) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
 
   responseRate: (
     parent: User,
@@ -1401,7 +1404,7 @@ export interface User_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Message[] | null | Promise<Message[] | null>;
+  ) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
 
   updatedAt: (
     parent: User,
@@ -1633,7 +1636,7 @@ export type Place_Reviews_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Review[] | Promise<Review[]>;
+) => Iterable<Review> | Promise<Iterable<Review>>;
 
 export type Place_Amenities_Resolver = (
   parent: Place,
@@ -1696,14 +1699,14 @@ export type Place_Bookings_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Booking[] | Promise<Booking[]>;
+) => Iterable<Booking> | Promise<Iterable<Booking>>;
 
 export type Place_Pictures_Resolver = (
   parent: Place,
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Picture[] | null | Promise<Picture[] | null>;
+) => Iterable<Picture> | null | Promise<Iterable<Picture> | null>;
 
 export type Place_Popularity_Resolver = (
   parent: Place,
@@ -1788,7 +1791,7 @@ export interface Place_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Review[] | Promise<Review[]>;
+  ) => Iterable<Review> | Promise<Iterable<Review>>;
 
   amenities: (
     parent: Place,
@@ -1851,14 +1854,14 @@ export interface Place_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Booking[] | Promise<Booking[]>;
+  ) => Iterable<Booking> | Promise<Iterable<Booking>>;
 
   pictures: (
     parent: Place,
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Picture[] | null | Promise<Picture[] | null>;
+  ) => Iterable<Picture> | null | Promise<Iterable<Picture> | null>;
 
   popularity: (
     parent: Place,
@@ -3178,7 +3181,7 @@ export type PaymentAccount_Payments_Resolver = (
   args: {},
   ctx: Context,
   info: GraphQLResolveInfo
-) => Payment[] | Promise<Payment[]>;
+) => Iterable<Payment> | Promise<Iterable<Payment>>;
 
 export type PaymentAccount_Paypal_Resolver = (
   parent: PaymentAccount,
@@ -3228,7 +3231,7 @@ export interface PaymentAccount_Resolvers {
     args: {},
     ctx: Context,
     info: GraphQLResolveInfo
-  ) => Payment[] | Promise<Payment[]>;
+  ) => Iterable<Payment> | Promise<Iterable<Payment>>;
 
   paypal: (
     parent: PaymentAccount,

--- a/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -551,9 +551,9 @@ export namespace QueryResolvers {
         ctx: Context,
         info: GraphQLResolveInfo
       ) =>
-        | Array<Image | Video | null>
+        | Iterable<Image | Video | null>
         | null
-        | Promise<Array<Image | Video | null> | null>
+        | Promise<Iterable<Image | Video | null> | null>
       )
     | {
         fragment: string;
@@ -563,9 +563,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<Image | Video | null>
+          | Iterable<Image | Video | null>
           | null
-          | Promise<Array<Image | Video | null> | null>;
+          | Promise<Iterable<Image | Video | null> | null>;
       };
 
   export type MediaItemResolver =
@@ -593,9 +593,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<Image | Video | null>
+          | Iterable<Image | Video | null>
           | null
-          | Promise<Array<Image | Video | null> | null>
+          | Promise<Iterable<Image | Video | null> | null>
         )
       | {
           fragment: string;
@@ -605,9 +605,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<Image | Video | null>
+            | Iterable<Image | Video | null>
             | null
-            | Promise<Array<Image | Video | null> | null>;
+            | Promise<Iterable<Image | Video | null> | null>;
         };
 
     mediaItem:
@@ -1313,7 +1313,11 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+      ) =>
+        | Iterable<Number | null>
+        | null
+        | Promise<Iterable<Number | null> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -1321,7 +1325,10 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+        ) =>
+          | Iterable<Number | null>
+          | null
+          | Promise<Iterable<Number | null> | null>;
       };
 
   export type Custom_array_requiredResolver =
@@ -1330,7 +1337,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<Number | null> | Promise<Array<Number | null>>)
+      ) => Iterable<Number | null> | Promise<Iterable<Number | null>>)
     | {
         fragment: string;
         resolve: (
@@ -1338,7 +1345,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | Promise<Array<Number | null>>;
+        ) => Iterable<Number | null> | Promise<Iterable<Number | null>>;
       };
 
   export type Custom_with_argResolver =
@@ -1415,7 +1422,11 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>)
+      ) =>
+        | Iterable<boolean | null>
+        | null
+        | Promise<Iterable<boolean | null> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -1424,9 +1435,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<boolean | null>
+          | Iterable<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>;
+          | Promise<Iterable<boolean | null> | null>;
       };
 
   export type Scalar_array_requiredResolver =
@@ -1435,7 +1446,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+      ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>)
     | {
         fragment: string;
         resolve: (
@@ -1443,7 +1454,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+        ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
       };
 
   export type Scalar_with_argResolver =
@@ -1538,7 +1549,11 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+        ) =>
+          | Iterable<Number | null>
+          | null
+          | Promise<Iterable<Number | null> | null>
+        )
       | {
           fragment: string;
           resolve: (
@@ -1547,9 +1562,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<Number | null>
+            | Iterable<Number | null>
             | null
-            | Promise<Array<Number | null> | null>;
+            | Promise<Iterable<Number | null> | null>;
         };
 
     custom_array_required:
@@ -1558,7 +1573,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | Promise<Array<Number | null>>)
+        ) => Iterable<Number | null> | Promise<Iterable<Number | null>>)
       | {
           fragment: string;
           resolve: (
@@ -1566,7 +1581,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<Number | null> | Promise<Array<Number | null>>;
+          ) => Iterable<Number | null> | Promise<Iterable<Number | null>>;
         };
 
     custom_with_arg:
@@ -1644,9 +1659,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<boolean | null>
+          | Iterable<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>
+          | Promise<Iterable<boolean | null> | null>
         )
       | {
           fragment: string;
@@ -1656,9 +1671,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<boolean | null>
+            | Iterable<boolean | null>
             | null
-            | Promise<Array<boolean | null> | null>;
+            | Promise<Iterable<boolean | null> | null>;
         };
 
     scalar_array_required:
@@ -1667,7 +1682,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+        ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>)
       | {
           fragment: string;
           resolve: (
@@ -1675,7 +1690,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+          ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
         };
 
     scalar_with_arg:
@@ -1910,7 +1925,10 @@ export namespace QueryResolvers {
         args: ArgsUsers,
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<Student | Professor> | Promise<Array<Student | Professor>>)
+      ) =>
+        | Iterable<Student | Professor>
+        | Promise<Iterable<Student | Professor>>
+      )
     | {
         fragment: string;
         resolve: (
@@ -1918,7 +1936,9 @@ export namespace QueryResolvers {
           args: ArgsUsers,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+        ) =>
+          | Iterable<Student | Professor>
+          | Promise<Iterable<Student | Professor>>;
       };
 
   export interface Type {
@@ -1928,7 +1948,10 @@ export namespace QueryResolvers {
           args: ArgsUsers,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Student | Professor> | Promise<Array<Student | Professor>>)
+        ) =>
+          | Iterable<Student | Professor>
+          | Promise<Iterable<Student | Professor>>
+        )
       | {
           fragment: string;
           resolve: (
@@ -1936,7 +1959,9 @@ export namespace QueryResolvers {
             args: ArgsUsers,
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<Student | Professor> | Promise<Array<Student | Professor>>;
+          ) =>
+            | Iterable<Student | Professor>
+            | Promise<Iterable<Student | Professor>>;
         };
   }
 }
@@ -2462,9 +2487,9 @@ export namespace QueryResolvers {
         ctx: Context,
         info: GraphQLResolveInfo
       ) =>
-        | Array<NumberNode | null>
+        | Iterable<NumberNode | null>
         | null
-        | Promise<Array<NumberNode | null> | null>
+        | Promise<Iterable<NumberNode | null> | null>
       )
     | {
         fragment: string;
@@ -2474,9 +2499,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<NumberNode | null>
+          | Iterable<NumberNode | null>
           | null
-          | Promise<Array<NumberNode | null> | null>;
+          | Promise<Iterable<NumberNode | null> | null>;
       };
 
   export type Custom_array_requiredResolver =
@@ -2485,7 +2510,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>)
+      ) => Iterable<NumberNode | null> | Promise<Iterable<NumberNode | null>>)
     | {
         fragment: string;
         resolve: (
@@ -2493,7 +2518,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+        ) => Iterable<NumberNode | null> | Promise<Iterable<NumberNode | null>>;
       };
 
   export type Custom_with_argResolver =
@@ -2570,7 +2595,11 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>)
+      ) =>
+        | Iterable<boolean | null>
+        | null
+        | Promise<Iterable<boolean | null> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -2579,9 +2608,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<boolean | null>
+          | Iterable<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>;
+          | Promise<Iterable<boolean | null> | null>;
       };
 
   export type Scalar_array_requiredResolver =
@@ -2590,7 +2619,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+      ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>)
     | {
         fragment: string;
         resolve: (
@@ -2598,7 +2627,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+        ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
       };
 
   export type Scalar_with_argResolver =
@@ -2694,9 +2723,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<NumberNode | null>
+          | Iterable<NumberNode | null>
           | null
-          | Promise<Array<NumberNode | null> | null>
+          | Promise<Iterable<NumberNode | null> | null>
         )
       | {
           fragment: string;
@@ -2706,9 +2735,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<NumberNode | null>
+            | Iterable<NumberNode | null>
             | null
-            | Promise<Array<NumberNode | null> | null>;
+            | Promise<Iterable<NumberNode | null> | null>;
         };
 
     custom_array_required:
@@ -2717,7 +2746,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>)
+        ) => Iterable<NumberNode | null> | Promise<Iterable<NumberNode | null>>)
       | {
           fragment: string;
           resolve: (
@@ -2725,7 +2754,9 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<NumberNode | null> | Promise<Array<NumberNode | null>>;
+          ) =>
+            | Iterable<NumberNode | null>
+            | Promise<Iterable<NumberNode | null>>;
         };
 
     custom_with_arg:
@@ -2803,9 +2834,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<boolean | null>
+          | Iterable<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>
+          | Promise<Iterable<boolean | null> | null>
         )
       | {
           fragment: string;
@@ -2815,9 +2846,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<boolean | null>
+            | Iterable<boolean | null>
             | null
-            | Promise<Array<boolean | null> | null>;
+            | Promise<Iterable<boolean | null> | null>;
         };
 
     scalar_array_required:
@@ -2826,7 +2857,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+        ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>)
       | {
           fragment: string;
           resolve: (
@@ -2834,7 +2865,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+          ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
         };
 
     scalar_with_arg:
@@ -3132,7 +3163,11 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+      ) =>
+        | Iterable<Number | null>
+        | null
+        | Promise<Iterable<Number | null> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -3140,7 +3175,10 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>;
+        ) =>
+          | Iterable<Number | null>
+          | null
+          | Promise<Iterable<Number | null> | null>;
       };
 
   export type Custom_array_requiredResolver =
@@ -3149,7 +3187,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<Number | null> | Promise<Array<Number | null>>)
+      ) => Iterable<Number | null> | Promise<Iterable<Number | null>>)
     | {
         fragment: string;
         resolve: (
@@ -3157,7 +3195,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | Promise<Array<Number | null>>;
+        ) => Iterable<Number | null> | Promise<Iterable<Number | null>>;
       };
 
   export type Custom_with_argResolver =
@@ -3234,7 +3272,11 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<boolean | null> | null | Promise<Array<boolean | null> | null>)
+      ) =>
+        | Iterable<boolean | null>
+        | null
+        | Promise<Iterable<boolean | null> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -3243,9 +3285,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<boolean | null>
+          | Iterable<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>;
+          | Promise<Iterable<boolean | null> | null>;
       };
 
   export type Scalar_array_requiredResolver =
@@ -3254,7 +3296,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+      ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>)
     | {
         fragment: string;
         resolve: (
@@ -3262,7 +3304,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+        ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
       };
 
   export type Scalar_with_argResolver =
@@ -3357,7 +3399,11 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | null | Promise<Array<Number | null> | null>)
+        ) =>
+          | Iterable<Number | null>
+          | null
+          | Promise<Iterable<Number | null> | null>
+        )
       | {
           fragment: string;
           resolve: (
@@ -3366,9 +3412,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<Number | null>
+            | Iterable<Number | null>
             | null
-            | Promise<Array<Number | null> | null>;
+            | Promise<Iterable<Number | null> | null>;
         };
 
     custom_array_required:
@@ -3377,7 +3423,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<Number | null> | Promise<Array<Number | null>>)
+        ) => Iterable<Number | null> | Promise<Iterable<Number | null>>)
       | {
           fragment: string;
           resolve: (
@@ -3385,7 +3431,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<Number | null> | Promise<Array<Number | null>>;
+          ) => Iterable<Number | null> | Promise<Iterable<Number | null>>;
         };
 
     custom_with_arg:
@@ -3463,9 +3509,9 @@ export namespace QueryResolvers {
           ctx: Context,
           info: GraphQLResolveInfo
         ) =>
-          | Array<boolean | null>
+          | Iterable<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>
+          | Promise<Iterable<boolean | null> | null>
         )
       | {
           fragment: string;
@@ -3475,9 +3521,9 @@ export namespace QueryResolvers {
             ctx: Context,
             info: GraphQLResolveInfo
           ) =>
-            | Array<boolean | null>
+            | Iterable<boolean | null>
             | null
-            | Promise<Array<boolean | null> | null>;
+            | Promise<Iterable<boolean | null> | null>;
         };
 
     scalar_array_required:
@@ -3486,7 +3532,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Array<boolean | null> | Promise<Array<boolean | null>>)
+        ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>)
       | {
           fragment: string;
           resolve: (
@@ -3494,7 +3540,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Array<boolean | null> | Promise<Array<boolean | null>>;
+          ) => Iterable<boolean | null> | Promise<Iterable<boolean | null>>;
         };
 
     scalar_with_arg:

--- a/packages/graphqlgen/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -72,7 +72,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Experience[] | Promise<Experience[]>)
+      ) => Iterable<Experience> | Promise<Iterable<Experience>>)
     | {
         fragment: string;
         resolve: (
@@ -80,7 +80,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Experience[] | Promise<Experience[]>;
+        ) => Iterable<Experience> | Promise<Iterable<Experience>>;
       };
 
   export type TopHomesResolver =
@@ -89,7 +89,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Home[] | Promise<Home[]>)
+      ) => Iterable<Home> | Promise<Iterable<Home>>)
     | {
         fragment: string;
         resolve: (
@@ -97,7 +97,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Home[] | Promise<Home[]>;
+        ) => Iterable<Home> | Promise<Iterable<Home>>;
       };
 
   export type HomesInPriceRangeResolver =
@@ -106,7 +106,7 @@ export namespace QueryResolvers {
         args: ArgsHomesInPriceRange,
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Home[] | Promise<Home[]>)
+      ) => Iterable<Home> | Promise<Iterable<Home>>)
     | {
         fragment: string;
         resolve: (
@@ -114,7 +114,7 @@ export namespace QueryResolvers {
           args: ArgsHomesInPriceRange,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Home[] | Promise<Home[]>;
+        ) => Iterable<Home> | Promise<Iterable<Home>>;
       };
 
   export type TopReservationsResolver =
@@ -123,7 +123,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Reservation[] | Promise<Reservation[]>)
+      ) => Iterable<Reservation> | Promise<Iterable<Reservation>>)
     | {
         fragment: string;
         resolve: (
@@ -131,7 +131,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Reservation[] | Promise<Reservation[]>;
+        ) => Iterable<Reservation> | Promise<Iterable<Reservation>>;
       };
 
   export type FeaturedDestinationsResolver =
@@ -140,7 +140,7 @@ export namespace QueryResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Neighbourhood[] | Promise<Neighbourhood[]>)
+      ) => Iterable<Neighbourhood> | Promise<Iterable<Neighbourhood>>)
     | {
         fragment: string;
         resolve: (
@@ -148,7 +148,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+        ) => Iterable<Neighbourhood> | Promise<Iterable<Neighbourhood>>;
       };
 
   export type ExperiencesByCityResolver =
@@ -157,7 +157,7 @@ export namespace QueryResolvers {
         args: ArgsExperiencesByCity,
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>)
+      ) => Iterable<ExperiencesByCity> | Promise<Iterable<ExperiencesByCity>>)
     | {
         fragment: string;
         resolve: (
@@ -165,7 +165,7 @@ export namespace QueryResolvers {
           args: ArgsExperiencesByCity,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+        ) => Iterable<ExperiencesByCity> | Promise<Iterable<ExperiencesByCity>>;
       };
 
   export type ViewerResolver =
@@ -209,7 +209,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Experience[] | Promise<Experience[]>)
+        ) => Iterable<Experience> | Promise<Iterable<Experience>>)
       | {
           fragment: string;
           resolve: (
@@ -217,7 +217,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Experience[] | Promise<Experience[]>;
+          ) => Iterable<Experience> | Promise<Iterable<Experience>>;
         };
 
     topHomes:
@@ -226,7 +226,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Home[] | Promise<Home[]>)
+        ) => Iterable<Home> | Promise<Iterable<Home>>)
       | {
           fragment: string;
           resolve: (
@@ -234,7 +234,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Home[] | Promise<Home[]>;
+          ) => Iterable<Home> | Promise<Iterable<Home>>;
         };
 
     homesInPriceRange:
@@ -243,7 +243,7 @@ export namespace QueryResolvers {
           args: ArgsHomesInPriceRange,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Home[] | Promise<Home[]>)
+        ) => Iterable<Home> | Promise<Iterable<Home>>)
       | {
           fragment: string;
           resolve: (
@@ -251,7 +251,7 @@ export namespace QueryResolvers {
             args: ArgsHomesInPriceRange,
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Home[] | Promise<Home[]>;
+          ) => Iterable<Home> | Promise<Iterable<Home>>;
         };
 
     topReservations:
@@ -260,7 +260,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Reservation[] | Promise<Reservation[]>)
+        ) => Iterable<Reservation> | Promise<Iterable<Reservation>>)
       | {
           fragment: string;
           resolve: (
@@ -268,7 +268,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Reservation[] | Promise<Reservation[]>;
+          ) => Iterable<Reservation> | Promise<Iterable<Reservation>>;
         };
 
     featuredDestinations:
@@ -277,7 +277,7 @@ export namespace QueryResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Neighbourhood[] | Promise<Neighbourhood[]>)
+        ) => Iterable<Neighbourhood> | Promise<Iterable<Neighbourhood>>)
       | {
           fragment: string;
           resolve: (
@@ -285,7 +285,7 @@ export namespace QueryResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Neighbourhood[] | Promise<Neighbourhood[]>;
+          ) => Iterable<Neighbourhood> | Promise<Iterable<Neighbourhood>>;
         };
 
     experiencesByCity:
@@ -294,7 +294,7 @@ export namespace QueryResolvers {
           args: ArgsExperiencesByCity,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>)
+        ) => Iterable<ExperiencesByCity> | Promise<Iterable<ExperiencesByCity>>)
       | {
           fragment: string;
           resolve: (
@@ -302,7 +302,9 @@ export namespace QueryResolvers {
             args: ArgsExperiencesByCity,
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => ExperiencesByCity[] | Promise<ExperiencesByCity[]>;
+          ) =>
+            | Iterable<ExperiencesByCity>
+            | Promise<Iterable<ExperiencesByCity>>;
         };
 
     viewer:
@@ -445,7 +447,7 @@ export namespace ExperienceResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Review[] | Promise<Review[]>)
+      ) => Iterable<Review> | Promise<Iterable<Review>>)
     | {
         fragment: string;
         resolve: (
@@ -453,7 +455,7 @@ export namespace ExperienceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Review[] | Promise<Review[]>;
+        ) => Iterable<Review> | Promise<Iterable<Review>>;
       };
 
   export type PreviewResolver =
@@ -582,7 +584,7 @@ export namespace ExperienceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Review[] | Promise<Review[]>)
+        ) => Iterable<Review> | Promise<Iterable<Review>>)
       | {
           fragment: string;
           resolve: (
@@ -590,7 +592,7 @@ export namespace ExperienceResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Review[] | Promise<Review[]>;
+          ) => Iterable<Review> | Promise<Iterable<Review>>;
         };
 
     preview:
@@ -1502,7 +1504,7 @@ export namespace HomeResolvers {
         args: ArgsPictures,
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Picture[] | Promise<Picture[]>)
+      ) => Iterable<Picture> | Promise<Iterable<Picture>>)
     | {
         fragment: string;
         resolve: (
@@ -1510,7 +1512,7 @@ export namespace HomeResolvers {
           args: ArgsPictures,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Picture[] | Promise<Picture[]>;
+        ) => Iterable<Picture> | Promise<Iterable<Picture>>;
       };
 
   export type PerNightResolver =
@@ -1622,7 +1624,7 @@ export namespace HomeResolvers {
           args: ArgsPictures,
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Picture[] | Promise<Picture[]>)
+        ) => Iterable<Picture> | Promise<Iterable<Picture>>)
       | {
           fragment: string;
           resolve: (
@@ -1630,7 +1632,7 @@ export namespace HomeResolvers {
             args: ArgsPictures,
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Picture[] | Promise<Picture[]>;
+          ) => Iterable<Picture> | Promise<Iterable<Picture>>;
         };
 
     perNight:
@@ -1721,7 +1723,7 @@ export namespace ReservationResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Picture[] | Promise<Picture[]>)
+      ) => Iterable<Picture> | Promise<Iterable<Picture>>)
     | {
         fragment: string;
         resolve: (
@@ -1729,7 +1731,7 @@ export namespace ReservationResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Picture[] | Promise<Picture[]>;
+        ) => Iterable<Picture> | Promise<Iterable<Picture>>;
       };
 
   export type LocationResolver =
@@ -1858,7 +1860,7 @@ export namespace ReservationResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Picture[] | Promise<Picture[]>)
+        ) => Iterable<Picture> | Promise<Iterable<Picture>>)
       | {
           fragment: string;
           resolve: (
@@ -1866,7 +1868,7 @@ export namespace ReservationResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Picture[] | Promise<Picture[]>;
+          ) => Iterable<Picture> | Promise<Iterable<Picture>>;
         };
 
     location:
@@ -2281,7 +2283,7 @@ export namespace ExperiencesByCityResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Experience[] | Promise<Experience[]>)
+      ) => Iterable<Experience> | Promise<Iterable<Experience>>)
     | {
         fragment: string;
         resolve: (
@@ -2289,7 +2291,7 @@ export namespace ExperiencesByCityResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Experience[] | Promise<Experience[]>;
+        ) => Iterable<Experience> | Promise<Iterable<Experience>>;
       };
 
   export type CityResolver =
@@ -2316,7 +2318,7 @@ export namespace ExperiencesByCityResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Experience[] | Promise<Experience[]>)
+        ) => Iterable<Experience> | Promise<Iterable<Experience>>)
       | {
           fragment: string;
           resolve: (
@@ -2324,7 +2326,7 @@ export namespace ExperiencesByCityResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Experience[] | Promise<Experience[]>;
+          ) => Iterable<Experience> | Promise<Iterable<Experience>>;
         };
 
     city:
@@ -2375,7 +2377,7 @@ export namespace ViewerResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Booking[] | Promise<Booking[]>)
+      ) => Iterable<Booking> | Promise<Iterable<Booking>>)
     | {
         fragment: string;
         resolve: (
@@ -2383,7 +2385,7 @@ export namespace ViewerResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Booking[] | Promise<Booking[]>;
+        ) => Iterable<Booking> | Promise<Iterable<Booking>>;
       };
 
   export interface Type {
@@ -2410,7 +2412,7 @@ export namespace ViewerResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Booking[] | Promise<Booking[]>)
+        ) => Iterable<Booking> | Promise<Iterable<Booking>>)
       | {
           fragment: string;
           resolve: (
@@ -2418,7 +2420,7 @@ export namespace ViewerResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Booking[] | Promise<Booking[]>;
+          ) => Iterable<Booking> | Promise<Iterable<Booking>>;
         };
   }
 }
@@ -2453,7 +2455,7 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Booking[] | null | Promise<Booking[] | null>)
+      ) => Iterable<Booking> | null | Promise<Iterable<Booking> | null>)
     | {
         fragment: string;
         resolve: (
@@ -2461,7 +2463,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Booking[] | null | Promise<Booking[] | null>;
+        ) => Iterable<Booking> | null | Promise<Iterable<Booking> | null>;
       };
 
   export type CreatedAtResolver =
@@ -2521,7 +2523,7 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Experience[] | null | Promise<Experience[] | null>)
+      ) => Iterable<Experience> | null | Promise<Iterable<Experience> | null>)
     | {
         fragment: string;
         resolve: (
@@ -2529,7 +2531,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Experience[] | null | Promise<Experience[] | null>;
+        ) => Iterable<Experience> | null | Promise<Iterable<Experience> | null>;
       };
 
   export type IdResolver =
@@ -2606,7 +2608,11 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Notification[] | null | Promise<Notification[] | null>)
+      ) =>
+        | Iterable<Notification>
+        | null
+        | Promise<Iterable<Notification> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -2614,7 +2620,10 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Notification[] | null | Promise<Notification[] | null>;
+        ) =>
+          | Iterable<Notification>
+          | null
+          | Promise<Iterable<Notification> | null>;
       };
 
   export type OwnedPlacesResolver =
@@ -2623,7 +2632,7 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Place[] | null | Promise<Place[] | null>)
+      ) => Iterable<Place> | null | Promise<Iterable<Place> | null>)
     | {
         fragment: string;
         resolve: (
@@ -2631,7 +2640,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Place[] | null | Promise<Place[] | null>;
+        ) => Iterable<Place> | null | Promise<Iterable<Place> | null>;
       };
 
   export type PaymentAccountResolver =
@@ -2640,7 +2649,11 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>)
+      ) =>
+        | Iterable<PaymentAccount>
+        | null
+        | Promise<Iterable<PaymentAccount> | null>
+      )
     | {
         fragment: string;
         resolve: (
@@ -2648,7 +2661,10 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+        ) =>
+          | Iterable<PaymentAccount>
+          | null
+          | Promise<Iterable<PaymentAccount> | null>;
       };
 
   export type PhoneResolver =
@@ -2691,7 +2707,7 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Message[] | null | Promise<Message[] | null>)
+      ) => Iterable<Message> | null | Promise<Iterable<Message> | null>)
     | {
         fragment: string;
         resolve: (
@@ -2699,7 +2715,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Message[] | null | Promise<Message[] | null>;
+        ) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
       };
 
   export type ResponseRateResolver =
@@ -2742,7 +2758,7 @@ export namespace UserResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Message[] | null | Promise<Message[] | null>)
+      ) => Iterable<Message> | null | Promise<Iterable<Message> | null>)
     | {
         fragment: string;
         resolve: (
@@ -2750,7 +2766,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Message[] | null | Promise<Message[] | null>;
+        ) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
       };
 
   export type UpdatedAtResolver =
@@ -2794,7 +2810,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Booking[] | null | Promise<Booking[] | null>)
+        ) => Iterable<Booking> | null | Promise<Iterable<Booking> | null>)
       | {
           fragment: string;
           resolve: (
@@ -2802,7 +2818,7 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Booking[] | null | Promise<Booking[] | null>;
+          ) => Iterable<Booking> | null | Promise<Iterable<Booking> | null>;
         };
 
     createdAt:
@@ -2862,7 +2878,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Experience[] | null | Promise<Experience[] | null>)
+        ) => Iterable<Experience> | null | Promise<Iterable<Experience> | null>)
       | {
           fragment: string;
           resolve: (
@@ -2870,7 +2886,10 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Experience[] | null | Promise<Experience[] | null>;
+          ) =>
+            | Iterable<Experience>
+            | null
+            | Promise<Iterable<Experience> | null>;
         };
 
     id:
@@ -2947,7 +2966,11 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Notification[] | null | Promise<Notification[] | null>)
+        ) =>
+          | Iterable<Notification>
+          | null
+          | Promise<Iterable<Notification> | null>
+        )
       | {
           fragment: string;
           resolve: (
@@ -2955,7 +2978,10 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Notification[] | null | Promise<Notification[] | null>;
+          ) =>
+            | Iterable<Notification>
+            | null
+            | Promise<Iterable<Notification> | null>;
         };
 
     ownedPlaces:
@@ -2964,7 +2990,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Place[] | null | Promise<Place[] | null>)
+        ) => Iterable<Place> | null | Promise<Iterable<Place> | null>)
       | {
           fragment: string;
           resolve: (
@@ -2972,7 +2998,7 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Place[] | null | Promise<Place[] | null>;
+          ) => Iterable<Place> | null | Promise<Iterable<Place> | null>;
         };
 
     paymentAccount:
@@ -2981,7 +3007,11 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>)
+        ) =>
+          | Iterable<PaymentAccount>
+          | null
+          | Promise<Iterable<PaymentAccount> | null>
+        )
       | {
           fragment: string;
           resolve: (
@@ -2989,7 +3019,10 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => PaymentAccount[] | null | Promise<PaymentAccount[] | null>;
+          ) =>
+            | Iterable<PaymentAccount>
+            | null
+            | Promise<Iterable<PaymentAccount> | null>;
         };
 
     phone:
@@ -3032,7 +3065,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Message[] | null | Promise<Message[] | null>)
+        ) => Iterable<Message> | null | Promise<Iterable<Message> | null>)
       | {
           fragment: string;
           resolve: (
@@ -3040,7 +3073,7 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Message[] | null | Promise<Message[] | null>;
+          ) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
         };
 
     responseRate:
@@ -3083,7 +3116,7 @@ export namespace UserResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Message[] | null | Promise<Message[] | null>)
+        ) => Iterable<Message> | null | Promise<Iterable<Message> | null>)
       | {
           fragment: string;
           resolve: (
@@ -3091,7 +3124,7 @@ export namespace UserResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Message[] | null | Promise<Message[] | null>;
+          ) => Iterable<Message> | null | Promise<Iterable<Message> | null>;
         };
 
     updatedAt:
@@ -3587,7 +3620,7 @@ export namespace PlaceResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Review[] | Promise<Review[]>)
+      ) => Iterable<Review> | Promise<Iterable<Review>>)
     | {
         fragment: string;
         resolve: (
@@ -3595,7 +3628,7 @@ export namespace PlaceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Review[] | Promise<Review[]>;
+        ) => Iterable<Review> | Promise<Iterable<Review>>;
       };
 
   export type AmenitiesResolver =
@@ -3740,7 +3773,7 @@ export namespace PlaceResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Booking[] | Promise<Booking[]>)
+      ) => Iterable<Booking> | Promise<Iterable<Booking>>)
     | {
         fragment: string;
         resolve: (
@@ -3748,7 +3781,7 @@ export namespace PlaceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Booking[] | Promise<Booking[]>;
+        ) => Iterable<Booking> | Promise<Iterable<Booking>>;
       };
 
   export type PicturesResolver =
@@ -3757,7 +3790,7 @@ export namespace PlaceResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Picture[] | null | Promise<Picture[] | null>)
+      ) => Iterable<Picture> | null | Promise<Iterable<Picture> | null>)
     | {
         fragment: string;
         resolve: (
@@ -3765,7 +3798,7 @@ export namespace PlaceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Picture[] | null | Promise<Picture[] | null>;
+        ) => Iterable<Picture> | null | Promise<Iterable<Picture> | null>;
       };
 
   export type PopularityResolver =
@@ -3962,7 +3995,7 @@ export namespace PlaceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Review[] | Promise<Review[]>)
+        ) => Iterable<Review> | Promise<Iterable<Review>>)
       | {
           fragment: string;
           resolve: (
@@ -3970,7 +4003,7 @@ export namespace PlaceResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Review[] | Promise<Review[]>;
+          ) => Iterable<Review> | Promise<Iterable<Review>>;
         };
 
     amenities:
@@ -4115,7 +4148,7 @@ export namespace PlaceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Booking[] | Promise<Booking[]>)
+        ) => Iterable<Booking> | Promise<Iterable<Booking>>)
       | {
           fragment: string;
           resolve: (
@@ -4123,7 +4156,7 @@ export namespace PlaceResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Booking[] | Promise<Booking[]>;
+          ) => Iterable<Booking> | Promise<Iterable<Booking>>;
         };
 
     pictures:
@@ -4132,7 +4165,7 @@ export namespace PlaceResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Picture[] | null | Promise<Picture[] | null>)
+        ) => Iterable<Picture> | null | Promise<Iterable<Picture> | null>)
       | {
           fragment: string;
           resolve: (
@@ -4140,7 +4173,7 @@ export namespace PlaceResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Picture[] | null | Promise<Picture[] | null>;
+          ) => Iterable<Picture> | null | Promise<Iterable<Picture> | null>;
         };
 
     popularity:
@@ -7124,7 +7157,7 @@ export namespace PaymentAccountResolvers {
         args: {},
         ctx: Context,
         info: GraphQLResolveInfo
-      ) => Payment[] | Promise<Payment[]>)
+      ) => Iterable<Payment> | Promise<Iterable<Payment>>)
     | {
         fragment: string;
         resolve: (
@@ -7132,7 +7165,7 @@ export namespace PaymentAccountResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Payment[] | Promise<Payment[]>;
+        ) => Iterable<Payment> | Promise<Iterable<Payment>>;
       };
 
   export type PaypalResolver =
@@ -7247,7 +7280,7 @@ export namespace PaymentAccountResolvers {
           args: {},
           ctx: Context,
           info: GraphQLResolveInfo
-        ) => Payment[] | Promise<Payment[]>)
+        ) => Iterable<Payment> | Promise<Iterable<Payment>>)
       | {
           fragment: string;
           resolve: (
@@ -7255,7 +7288,7 @@ export namespace PaymentAccountResolvers {
             args: {},
             ctx: Context,
             info: GraphQLResolveInfo
-          ) => Payment[] | Promise<Payment[]>;
+          ) => Iterable<Payment> | Promise<Iterable<Payment>>;
         };
 
     paypal:


### PR DESCRIPTION
GraphQL uses `iterall` and supports `Iterable` return values. This PR changes all return types to be iterable and keeps input types as arrays.