### PR TITLE
do not render default resolver when field has no type

### DIFF
--- a/packages/graphqlgen/src/generators/common.ts
+++ b/packages/graphqlgen/src/generators/common.ts
@@ -178,6 +178,10 @@ function shouldRenderDefaultResolver(
 
   const modelFieldType = modelField.getType()
 
+  if (modelFieldType === undefined) {
+    return false;
+  }
+
   // If both types are enums, and model definition enum is a subset of the graphql enum
   // Then render as defaultResolver
   // eg: given GraphQLEnum = 'A' | 'B' | 'C'


### PR DESCRIPTION
Not sure in which scenario this happens, but it does happen that `getType()` returns undefined, causing generation to fail.
By ensuring the type is not undefined, generation works fine.