### PR TITLE
Fix schema validate error

### DIFF
--- a/packages/graphqlgen-json-schema/src/definition.ts
+++ b/packages/graphqlgen-json-schema/src/definition.ts
@@ -7,6 +7,7 @@ export interface GraphQLGenDefinition {
   ['resolver-scaffolding']?: ResolverScaffolding
   ['default-resolvers']?: boolean
   ['iresolvers-augmentation']?: boolean
+  ['delegated-parent-resolvers']?: boolean
 }
 
 export interface Models {

--- a/packages/graphqlgen-json-schema/src/schema.json
+++ b/packages/graphqlgen-json-schema/src/schema.json
@@ -67,6 +67,18 @@
       },
       "required": ["output", "layout"],
       "additionalProperties": false
+    },
+    "iresolvers-augmentation": {
+      "description": "A boolean dictating if Apollo Server IResolvers type should be augmented so that it is compatible with graphqlgen `Resolvers` type",
+      "type": "boolean"
+    },
+    "default-resolvers": {
+      "description": "A boolean dictating if default resolvers will be generated or not",
+      "type": "boolean"
+    },
+    "delegated-parent-resolvers": {
+      "description": "A boolean dictating if the resolver signatures generated should include the signature for DelegatedParentResolvers",
+      "type": "boolean"
     }
   },
   "required": ["language", "schema", "models", "output"],

--- a/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/packages/graphqlgen/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -1515,7 +1515,8 @@ export namespace QueryResolvers {
         ) =>
           | Array<boolean | null>
           | null
-          | Promise<Array<boolean | null> | null>)
+          | Promise<Array<boolean | null> | null>
+        )
       | {
           fragment: string;
           resolve: (


### PR DESCRIPTION
FIX: https://github.com/prisma-labs/graphqlgen/issues/461, https://github.com/prisma-labs/graphqlgen/issues/470

graphqlgen-json-schema package's schema is missing following properties so I've added these props to it.

- iresolvers-augmentation
- default-resolvers
- delegated-parent-resolvers